### PR TITLE
subject and author indexed as text field

### DIFF
--- a/configs/orangelight/conf/schema.xml
+++ b/configs/orangelight/conf/schema.xml
@@ -704,15 +704,19 @@
         or to add multiple fields to the same field for easier/faster searching.  -->
    <!-- Copy Fields -->
 
-   
+   <!-- subject keyword -->
+   <copyField source="subject_display" dest="subject_t"/>
 
+   <!-- author keyword -->
+   <copyField source="author_display" dest="author_main_t"/>
+   <copyField source="author_s" dest="author_t"/>
 
    <!-- unstemmed fields -->
    <copyField source="title_display" dest="title_unstem_search"/>
    <copyField source="title_addl_t" dest="title_addl_unstem_search"/>
    <copyField source="title_added_entry_t" dest="title_added_entry_unstem_search"/>
    <copyField source="title_series_t" dest="title_series_unstem_search"/>
-   <copyField source="author_s" dest="author_unstem_search"/>
+   <copyField source="author_display" dest="author_unstem_search"/>
    <copyField source="author_addl_t" dest="author_addl_unstem_search"/>
    <copyField source="subject_t" dest="subject_unstem_search"/>
    <copyField source="subject_addl_t" dest="subject_addl_unstem_search"/>

--- a/configs/orangelight/conf/solrconfig.xml
+++ b/configs/orangelight/conf/solrconfig.xml
@@ -297,15 +297,17 @@
       </str>
       <str name="author_qf">
         author_unstem_search^200
+        author_main_t^100
         author_addl_unstem_search^50
-        author_s^20
+        author_t^20
         author_addl_t
         cjk_author
       </str>
       <str name="author_pf">
         author_unstem_search^2000
+        author_main_t^1000
         author_addl_unstem_search^500
-        author_s^200
+        author_t^200
         author_addl_t^10
         cjk_author^10
       </str>

--- a/spec/fixtures/1332805.json
+++ b/spec/fixtures/1332805.json
@@ -1,0 +1,170 @@
+{
+
+    "id": [
+        "1332805"
+    ],
+    "cjk_all": [
+        "Cairns, David, 1904-",
+        "The image of God in man / [by] David Cairns.",
+        "Revised ed. / with an introduction by David E. Jenkins.",
+        "London : Collins, 1973.",
+        "317 p. ; 18 cm.",
+        "The Fontana library of theology and philosophy",
+        "Includes bibliographical references and index.",
+        "Image of God.",
+        "1530450 rcppa 0 5743.232.1973 tr fr f"
+    ],
+    "author_display": [
+        "Cairns, David, 1904-"
+    ],
+    "author_sort": [
+        "Cairns, David, 1904-"
+    ],
+    "author_citation_display": [
+        "Cairns, David"
+    ],
+    "author_roles_1display": [
+        "{\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[],\"primary_author\":\"Cairns, David\"}"
+    ],
+    "author_s": [
+        "Cairns, David, 1904-"
+    ],
+    "marc_relator_display": [
+        "Author"
+    ],
+    "title_display": [
+        "The image of God in man / [by] David Cairns."
+    ],
+    "title_a_index": [
+        "The image of God in man /"
+    ],
+    "title_sort": [
+        "image of God in man / [by] David Cairns."
+    ],
+    "title_no_h_index": [
+        "The image of God in man / [by] David Cairns.",
+        "image of God in man / [by] David Cairns."
+    ],
+    "title_t": [
+        "The image of God in man / [by] David Cairns."
+    ],
+    "title_citation_display": [
+        "The image of God in man /"
+    ],
+    "series_title_index": [
+        "The Fontana library of theology and philosophy"
+    ],
+    "compiled_created_t": [
+        "The image of God in man / [by] David Cairns."
+    ],
+    "edition_display": [
+        "Revised ed. / with an introduction by David E. Jenkins."
+    ],
+    "pub_created_display": [
+        "London : Collins, 1973."
+    ],
+    "pub_created_s": [
+        "London : Collins, 1973."
+    ],
+    "pub_citation_display": [
+        "London: Collins"
+    ],
+    "pub_date_display": [
+        "1973"
+    ],
+    "pub_date_start_sort": [
+        "1973"
+    ],
+    "cataloged_tdt": [
+        "2000-06-13T04:00:00Z"
+    ],
+    "format": [
+        "Book"
+    ],
+    "description_display": [
+        "317 p. ; 18 cm."
+    ],
+    "description_t": [
+        "317 p. ; 18 cm."
+    ],
+    "series_display": [
+        "The Fontana library of theology and philosophy"
+    ],
+    "bib_ref_notes_display": [
+        "Includes bibliographical references and index."
+    ],
+    "language_facet": [
+        "English"
+    ],
+    "language_code_s": [
+        "eng"
+    ],
+    "subject_display": [
+        "Image of God"
+    ],
+    "subject_facet": [
+        "Image of God"
+    ],
+    "subject_topic_facet": [
+        "Image of God"
+    ],
+    "lc_1letter_facet": [
+        "B - Philosophy, Psychology, Religion"
+    ],
+    "lc_rest_facet": [
+        "BT - Doctrinal Theology"
+    ],
+    "call_number_scheme_facet": [
+        "Library of Congress"
+    ],
+    "call_number_group_facet": [
+        "B - Philosophy, Psychology, Religion"
+    ],
+    "call_number_full_facet": [
+        "BT - Doctrinal Theology"
+    ],
+    "isbn_display": [
+        "0006427049 :"
+    ],
+    "lccn_display": [
+        "   74185643  "
+    ],
+    "lccn_s": [
+        "74185643"
+    ],
+    "isbn_s": [
+        "9780006427049"
+    ],
+    "oclc_s": [
+        "855996"
+    ],
+    "standard_no_index": [
+        "ocm00855996"
+    ],
+    "other_version_s": [
+        "9780006427049",
+        "ocm00855996"
+    ],
+    "holdings_1display": [
+        "{\"1530450\":{\"location\":\"ReCAP\",\"library\":\"ReCAP\",\"location_code\":\"rcppa\",\"call_number\":\"5743.232.1973\",\"call_number_browse\":\"5743.232.1973\"}}"
+    ],
+    "location_code_s": [
+        "rcppa"
+    ],
+    "location_display": [
+        "ReCAP"
+    ],
+    "location": [
+        "ReCAP"
+    ],
+    "access_facet": [
+        "In the Library"
+    ],
+    "call_number_display": [
+        "5743.232.1973"
+    ],
+    "call_number_browse_s": [
+        "5743.232.1973"
+    ]
+
+}

--- a/spec/fixtures/454035.json
+++ b/spec/fixtures/454035.json
@@ -1,0 +1,144 @@
+{
+
+    "id": [
+        "454035"
+    ],
+    "cjk_all": [
+        "Rumayḥ, Ṭalʻat.",
+        "ʻUthmān al-lughz wa-al-usṭūrah / Ṭalʻat Rumayḥ.",
+        "al-Ṭabʻah 1.",
+        "al-Qāhirah : Sīnā, 1987.",
+        "242 p. : ill. (1 folded), facsims. ; 24 cm.",
+        "Includes bibliographical references.",
+        "ʻUthmān, ʻUthmān Aḥmad.",
+        "Engineers Egypt Biography.",
+        "494089 anxafst 1 DT107.83 .R85 1987"
+    ],
+    "author_display": [
+        "Rumayḥ, Ṭalʻat."
+    ],
+    "author_sort": [
+        "Rumayḥ, Ṭalʻat."
+    ],
+    "author_citation_display": [
+        "Rumayḥ, Ṭalʻat."
+    ],
+    "author_roles_1display": [
+        "{\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[],\"primary_author\":\"Rumayḥ, Ṭalʻat.\"}"
+    ],
+    "author_s": [
+        "Rumayḥ, Ṭalʻat."
+    ],
+    "marc_relator_display": [
+        "Author"
+    ],
+    "title_display": [
+        "ʻUthmān al-lughz wa-al-usṭūrah / Ṭalʻat Rumayḥ."
+    ],
+    "title_a_index": [
+        "ʻUthmān al-lughz wa-al-usṭūrah /"
+    ],
+    "title_sort": [
+        "ʻUthmān al-lughz wa-al-usṭūrah / Ṭalʻat Rumayḥ."
+    ],
+    "title_no_h_index": [
+        "ʻUthmān al-lughz wa-al-usṭūrah / Ṭalʻat Rumayḥ."
+    ],
+    "title_t": [
+        "ʻUthmān al-lughz wa-al-usṭūrah / Ṭalʻat Rumayḥ."
+    ],
+    "title_citation_display": [
+        "ʻUthmān al-lughz wa-al-usṭūrah /"
+    ],
+    "compiled_created_t": [
+        "ʻUthmān al-lughz wa-al-usṭūrah / Ṭalʻat Rumayḥ."
+    ],
+    "edition_display": [
+        "al-Ṭabʻah 1."
+    ],
+    "pub_created_display": [
+        "al-Qāhirah : Sīnā, 1987."
+    ],
+    "pub_created_s": [
+        "al-Qāhirah : Sīnā, 1987."
+    ],
+    "pub_citation_display": [
+        "al-Qāhirah: Sīnā"
+    ],
+    "pub_date_display": [
+        "1987"
+    ],
+    "pub_date_start_sort": [
+        "1987"
+    ],
+    "cataloged_tdt": [
+        "2000-06-13T04:00:00Z"
+    ],
+    "format": [
+        "Book"
+    ],
+    "description_display": [
+        "242 p. : ill. (1 folded), facsims. ; 24 cm."
+    ],
+    "description_t": [
+        "242 p. : ill. (1 folded), facsims. ; 24 cm."
+    ],
+    "bib_ref_notes_display": [
+        "Includes bibliographical references."
+    ],
+    "language_facet": [
+        "Arabic"
+    ],
+    "language_code_s": [
+        "ara"
+    ],
+    "subject_display": [
+        "ʻUthmān, ʻUthmān Aḥmad",
+        "Engineers—Egypt—Biography"
+    ],
+    "subject_facet": [
+        "ʻUthmān, ʻUthmān Aḥmad",
+        "Engineers—Egypt—Biography"
+    ],
+    "subject_topic_facet": [
+        "ʻUthmān, ʻUthmān Aḥmad",
+        "Engineers",
+        "Egypt",
+        "Biography"
+    ],
+    "genre_facet": [
+        "Biography"
+    ],
+    "oclc_s": [
+        "20588638"
+    ],
+    "standard_no_index": [
+        "20588638",
+        "NJPG88-B34220"
+    ],
+    "other_version_s": [
+        "ocm20588638"
+    ],
+    "holdings_1display": [
+        "{\"494089\":{\"location\":\"Forrestal Annex - Temporary\",\"library\":\"Forrestal Annex\",\"location_code\":\"anxafst\",\"call_number\":\"DT107.83 .R85 1987\",\"call_number_browse\":\"DT107.83 .R85 1987\"}}"
+    ],
+    "location_code_s": [
+        "anxafst"
+    ],
+    "location_display": [
+        "Forrestal Annex - Temporary"
+    ],
+    "location": [
+        "Forrestal Annex"
+    ],
+    "access_facet": [
+        "In the Library"
+    ],
+    "call_number_display": [
+        "DT107.83 .R85 1987"
+    ],
+    "call_number_browse_s": [
+        "DT107.83 .R85 1987"
+    ]
+
+}

--- a/spec/fixtures/484612.json
+++ b/spec/fixtures/484612.json
@@ -1,0 +1,146 @@
+{
+
+    "id": [
+        "484612"
+    ],
+    "cjk_all": [
+        "Fellbaum, Christiane.",
+        "On the middle construction in English / by Christiane Fellbaum.",
+        "Bloomington : Indiana University Linguistics Club, [c1986]",
+        "24 p. ; 28 cm.",
+        "\"July 1986.\"",
+        "Bibliography: p. 24.",
+        "English language Verb.",
+        "English language Syntax.",
+        "English language Semantics.",
+        "526451 f 1 PE1319 .F387"
+    ],
+    "author_display": [
+        "Fellbaum, Christiane"
+    ],
+    "author_sort": [
+        "Fellbaum, Christiane"
+    ],
+    "author_citation_display": [
+        "Fellbaum, Christiane"
+    ],
+    "author_roles_1display": [
+        "{\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[],\"primary_author\":\"Fellbaum, Christiane\"}"
+    ],
+    "author_s": [
+        "Fellbaum, Christiane"
+    ],
+    "marc_relator_display": [
+        "Author"
+    ],
+    "title_display": [
+        "On the middle construction in English / by Christiane Fellbaum."
+    ],
+    "title_a_index": [
+        "On the middle construction in English /"
+    ],
+    "title_sort": [
+        "On the middle construction in English / by Christiane Fellbaum."
+    ],
+    "title_no_h_index": [
+        "On the middle construction in English / by Christiane Fellbaum."
+    ],
+    "title_t": [
+        "On the middle construction in English / by Christiane Fellbaum."
+    ],
+    "title_citation_display": [
+        "On the middle construction in English /"
+    ],
+    "compiled_created_t": [
+        "On the middle construction in English / by Christiane Fellbaum."
+    ],
+    "pub_created_display": [
+        "Bloomington : Indiana University Linguistics Club, [c1986]"
+    ],
+    "pub_created_s": [
+        "Bloomington : Indiana University Linguistics Club, [c1986]"
+    ],
+    "pub_citation_display": [
+        "Bloomington: Indiana University Linguistics Club"
+    ],
+    "pub_date_display": [
+        "1986"
+    ],
+    "pub_date_start_sort": [
+        "1986"
+    ],
+    "cataloged_tdt": [
+        "2000-06-13T04:00:00Z"
+    ],
+    "format": [
+        "Book"
+    ],
+    "description_display": [
+        "24 p. ; 28 cm."
+    ],
+    "description_t": [
+        "24 p. ; 28 cm."
+    ],
+    "notes_display": [
+        "\"July 1986.\""
+    ],
+    "bib_ref_notes_display": [
+        "Bibliography: p. 24."
+    ],
+    "language_facet": [
+        "English"
+    ],
+    "language_code_s": [
+        "eng"
+    ],
+    "subject_display": [
+        "English language—Verb",
+        "English language—Syntax",
+        "English language—Semantics"
+    ],
+    "subject_facet": [
+        "English language—Verb",
+        "English language—Syntax",
+        "English language—Semantics"
+    ],
+    "subject_topic_facet": [
+        "English language",
+        "Verb",
+        "English language",
+        "Syntax",
+        "English language",
+        "Semantics"
+    ],
+    "oclc_s": [
+        "15057985"
+    ],
+    "standard_no_index": [
+        "15057985",
+        "NJPG88-B62473"
+    ],
+    "other_version_s": [
+        "ocm15057985"
+    ],
+    "holdings_1display": [
+        "{\"526451\":{\"location\":\"Firestone Library\",\"library\":\"Firestone Library\",\"location_code\":\"f\",\"call_number\":\"PE1319 .F387\",\"call_number_browse\":\"PE1319 .F387\"}}"
+    ],
+    "location_code_s": [
+        "f"
+    ],
+    "location_display": [
+        "Firestone Library"
+    ],
+    "location": [
+        "Firestone Library"
+    ],
+    "access_facet": [
+        "In the Library"
+    ],
+    "call_number_display": [
+        "PE1319 .F387"
+    ],
+    "call_number_browse_s": [
+        "PE1319 .F387"
+    ]
+
+}

--- a/spec/fixtures/5188770.json
+++ b/spec/fixtures/5188770.json
@@ -1,0 +1,170 @@
+{
+
+    "id": [
+        "5188770"
+    ],
+    "cjk_all": [
+        "Idioms and collocations : corpus-based linguistic and lexicographic studies / edited by Christiane Fellbaum.",
+        "London : Continuum, 2007.",
+        "vi, 219 p. ; 24 cm.",
+        "Corpus and discourse. Research in corpus and discourse",
+        "Includes bibliographical references (p. [203]-212) and index.",
+        "Corpora (Linguistics)",
+        "English language Idioms.",
+        "German language Idioms.",
+        "Collocation (Linguistics)",
+        "Fellbaum, Christiane.",
+        "5376085 f P128.C68 F45 2007"
+    ],
+    "author_citation_display": [
+        "Fellbaum, Christiane"
+    ],
+    "author_roles_1display": [
+        "{\"secondary_authors\":[\"Fellbaum, Christiane\"],\"translators\":[],\"editors\":[],\"compilers\":[]}"
+    ],
+    "author_s": [
+        "Fellbaum, Christiane"
+    ],
+    "title_display": [
+        "Idioms and collocations : corpus-based linguistic and lexicographic studies / edited by Christiane Fellbaum."
+    ],
+    "title_a_index": [
+        "Idioms and collocations :"
+    ],
+    "title_sort": [
+        "Idioms and collocations : corpus-based linguistic and lexicographic studies / edited by Christiane Fellbaum."
+    ],
+    "title_no_h_index": [
+        "Idioms and collocations : corpus-based linguistic and lexicographic studies / edited by Christiane Fellbaum."
+    ],
+    "title_t": [
+        "Idioms and collocations : corpus-based linguistic and lexicographic studies / edited by Christiane Fellbaum."
+    ],
+    "title_citation_display": [
+        "Idioms and collocations : corpus-based linguistic and lexicographic studies /"
+    ],
+    "series_title_index": [
+        "Corpus and discourse. Research in corpus and discourse"
+    ],
+    "compiled_created_t": [
+        "Idioms and collocations : corpus-based linguistic and lexicographic studies / edited by Christiane Fellbaum."
+    ],
+    "pub_created_display": [
+        "London : Continuum, 2007."
+    ],
+    "pub_created_s": [
+        "London : Continuum, 2007."
+    ],
+    "pub_citation_display": [
+        "London: Continuum"
+    ],
+    "pub_date_display": [
+        "2007"
+    ],
+    "pub_date_start_sort": [
+        "2007"
+    ],
+    "cataloged_tdt": [
+        "2007-06-20T14:09:02Z"
+    ],
+    "format": [
+        "Book"
+    ],
+    "description_display": [
+        "vi, 219 p. ; 24 cm."
+    ],
+    "description_t": [
+        "vi, 219 p. ; 24 cm."
+    ],
+    "series_display": [
+        "Corpus and discourse. Research in corpus and discourse"
+    ],
+    "bib_ref_notes_display": [
+        "Includes bibliographical references (p. [203]-212) and index."
+    ],
+    "language_facet": [
+        "English"
+    ],
+    "language_code_s": [
+        "eng"
+    ],
+    "subject_display": [
+        "Corpora (Linguistics)",
+        "English language—Idioms",
+        "German language—Idioms",
+        "Collocation (Linguistics)"
+    ],
+    "subject_facet": [
+        "Corpora (Linguistics)",
+        "English language—Idioms",
+        "German language—Idioms",
+        "Collocation (Linguistics)"
+    ],
+    "subject_topic_facet": [
+        "Corpora (Linguistics)",
+        "English language",
+        "Idioms",
+        "German language",
+        "Idioms",
+        "Collocation (Linguistics)"
+    ],
+    "lc_1letter_facet": [
+        "P - Language & Literature"
+    ],
+    "lc_rest_facet": [
+        "P - Language & Literature"
+    ],
+    "call_number_scheme_facet": [
+        "Library of Congress"
+    ],
+    "call_number_group_facet": [
+        "P - Language & Literature"
+    ],
+    "call_number_full_facet": [
+        "P - Language & Literature"
+    ],
+    "related_name_json_1display": [
+        "{\"Related name\":[\"Fellbaum, Christiane\"]}"
+    ],
+    "isbn_display": [
+        "082648994X",
+        "9780826489944 (hbk.)"
+    ],
+    "isbn_s": [
+        "9780826489944"
+    ],
+    "oclc_s": [
+        "76936654"
+    ],
+    "standard_no_index": [
+        "ocm76936654",
+        "L1750486",
+        "76936654"
+    ],
+    "other_version_s": [
+        "ocm76936654",
+        "9780826489944"
+    ],
+    "holdings_1display": [
+        "{\"5376085\":{\"location\":\"Firestone Library\",\"library\":\"Firestone Library\",\"location_code\":\"f\",\"call_number\":\"P128.C68 F45 2007\",\"call_number_browse\":\"P128.C68 F45 2007\"}}"
+    ],
+    "location_code_s": [
+        "f"
+    ],
+    "location_display": [
+        "Firestone Library"
+    ],
+    "location": [
+        "Firestone Library"
+    ],
+    "access_facet": [
+        "In the Library"
+    ],
+    "call_number_display": [
+        "P128.C68 F45 2007"
+    ],
+    "call_number_browse_s": [
+        "P128.C68 F45 2007"
+    ]
+
+}

--- a/spec/fixtures/7419275.json
+++ b/spec/fixtures/7419275.json
@@ -1,0 +1,144 @@
+{
+
+    "id": [
+        "7419275"
+    ],
+    "cjk_all": [
+        "Boroda, Moiseĭ, author.",
+        "Podarok vozhdi︠a︡ / Moiseĭ Boroda.",
+        "Sankt-Peterburg: Aleteĭi︠a︡, 2013.",
+        "285 pages ; 20 cm",
+        "text rdacontent",
+        "unmediated rdamedia",
+        "volume rdacarrier",
+        "7238413 rcppa PG3491.46.O67 P6 2013"
+    ],
+    "author_display": [
+        "Boroda, Moiseĭ"
+    ],
+    "author_sort": [
+        "Boroda, Moiseĭ"
+    ],
+    "author_citation_display": [
+        "Boroda, Moiseĭ"
+    ],
+    "author_roles_1display": [
+        "{\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[],\"primary_author\":\"Boroda, Moiseĭ\"}"
+    ],
+    "author_s": [
+        "Boroda, Moiseĭ"
+    ],
+    "marc_relator_display": [
+        "Author"
+    ],
+    "title_display": [
+        "Podarok vozhdi︠a︡ / Moiseĭ Boroda."
+    ],
+    "title_a_index": [
+        "Podarok vozhdi︠a︡ /"
+    ],
+    "title_sort": [
+        "Podarok vozhdi︠a︡ / Moiseĭ Boroda."
+    ],
+    "title_no_h_index": [
+        "Podarok vozhdi︠a︡ / Moiseĭ Boroda."
+    ],
+    "title_t": [
+        "Podarok vozhdi︠a︡ / Moiseĭ Boroda."
+    ],
+    "title_citation_display": [
+        "Podarok vozhdi︠a︡ /"
+    ],
+    "compiled_created_t": [
+        "Podarok vozhdi︠a︡ / Moiseĭ Boroda."
+    ],
+    "pub_created_display": [
+        "Sankt-Peterburg: Aleteĭi︠a︡, 2013."
+    ],
+    "pub_created_s": [
+        "Sankt-Peterburg: Aleteĭi︠a︡, 2013."
+    ],
+    "pub_citation_display": [
+        "Sankt-Peterburg: Aleteĭi︠a︡"
+    ],
+    "pub_date_display": [
+        "2013"
+    ],
+    "pub_date_start_sort": [
+        "2013"
+    ],
+    "cataloged_tdt": [
+        "2013-08-06T18:25:18Z"
+    ],
+    "format": [
+        "Book"
+    ],
+    "description_display": [
+        "285 pages ; 20 cm"
+    ],
+    "description_t": [
+        "285 pages ; 20 cm"
+    ],
+    "language_facet": [
+        "Russian"
+    ],
+    "language_code_s": [
+        "rus"
+    ],
+    "lc_1letter_facet": [
+        "P - Language & Literature"
+    ],
+    "lc_rest_facet": [
+        "PG - Slavic, Baltic, Albanian Languages, Russian Language & Literature"
+    ],
+    "call_number_scheme_facet": [
+        "Library of Congress"
+    ],
+    "call_number_group_facet": [
+        "P - Language & Literature"
+    ],
+    "call_number_full_facet": [
+        "PG - Slavic, Baltic, Albanian Languages, Russian Language & Literature"
+    ],
+    "isbn_display": [
+        "9785914197596",
+        "5914197597"
+    ],
+    "isbn_s": [
+        "9785914197596"
+    ],
+    "oclc_s": [
+        "843535405"
+    ],
+    "standard_no_index": [
+        "ocn843535405",
+        "703110",
+        "843535405"
+    ],
+    "other_version_s": [
+        "ocn843535405",
+        "9785914197596"
+    ],
+    "holdings_1display": [
+        "{\"7238413\":{\"location\":\"ReCAP\",\"library\":\"ReCAP\",\"location_code\":\"rcppa\",\"call_number\":\"PG3491.46.O67 P6 2013\",\"call_number_browse\":\"PG3491.46.O67 P6 2013\"}}"
+    ],
+    "location_code_s": [
+        "rcppa"
+    ],
+    "location_display": [
+        "ReCAP"
+    ],
+    "location": [
+        "ReCAP"
+    ],
+    "access_facet": [
+        "In the Library"
+    ],
+    "call_number_display": [
+        "PG3491.46.O67 P6 2013"
+    ],
+    "call_number_browse_s": [
+        "PG3491.46.O67 P6 2013"
+    ]
+
+}

--- a/spec/orangelight/author_search_spec.rb
+++ b/spec/orangelight/author_search_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+require 'json'
+
+describe 'author keyword search' do
+  def author_query_string q
+    "{!qf=$author_qf pf=$author_pf}#{q}"
+  end
+  before(:all) do
+    delete_all
+  end
+  describe 'diacritics' do
+    diacritic_name = '7419275'
+    before(:all) do
+      add_doc(diacritic_name)
+    end
+    it 'retrieves book when diacritics included' do
+      expect(solr_resp_doc_ids_only({ 'q' => author_query_string('Moiseĭ') })).to include(diacritic_name)
+    end
+    it 'retrieves book when diacritics excluded' do
+      expect(solr_resp_doc_ids_only({ 'q' => author_query_string('Moisei') })).to include(diacritic_name)
+    end
+  end
+  describe 'author 1xx field' do
+    author = '484612'
+    related_name = '5188770'
+    before(:all) do
+      add_doc(author)
+      add_doc(related_name)
+    end
+    it 'author 1xx match returned before 7xx match' do
+      expect(solr_resp_doc_ids_only({ 'q' => author_query_string('Fellbaum') })).to include(author).before(related_name)
+    end
+  end
+  after(:all) do
+    delete_all
+  end
+end

--- a/spec/orangelight/subject_search_spec.rb
+++ b/spec/orangelight/subject_search_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'json'
+
+describe 'subject keyword search' do
+  def subject_query_string q
+    "{!qf=$subject_qf pf=$subject_pf}#{q}"
+  end
+  before(:all) do
+    delete_all
+  end
+  describe 'diacritics' do
+    diacritic_subject = '454035'
+    before(:all) do
+      add_doc(diacritic_subject)
+    end
+    it 'retrieves book when diacritics included' do
+      expect(solr_resp_doc_ids_only({ 'q' => subject_query_string('ʻUthmān, ʻUthmān') })).to include(diacritic_subject)
+    end
+    it 'retrieves book when diacritics excluded' do
+      expect(solr_resp_doc_ids_only({ 'q' => subject_query_string('Uthman') })).to include(diacritic_subject)
+    end
+  end
+  describe 'stopwords' do
+    stop_word_subject = '1332805'
+    before(:all) do
+      add_doc(stop_word_subject)
+    end
+    it 'retrieves book when stop words included' do
+      expect(solr_resp_doc_ids_only({ 'q' => subject_query_string('image of god') })).to include(stop_word_subject)
+    end
+    it 'retrieves book when stop words excluded' do
+      expect(solr_resp_doc_ids_only({ 'q' => subject_query_string('image god') })).to include(stop_word_subject)
+    end
+  end
+  after(:all) do
+    delete_all
+  end
+end


### PR DESCRIPTION
Indexed subject and author fields as text fields, which support diacritics folding. Closes pulibrary/orangelight#515 and closes pulibrary/orangelight#249.
The text field also doesn't use the stopword filter (before only queries that excluded the stop word would match). Closes pulibrary/orangelight#505