### PR TITLE
use shared_context to allow contexts to access diff solr cores and instances

### DIFF
--- a/spec/orangelight/apostrophe_spec.rb
+++ b/spec/orangelight/apostrophe_spec.rb
@@ -2,12 +2,15 @@ require 'spec_helper'
 require 'json'
 
 describe 'apostrophes are stripped' do
+
+  include_context 'solr_helpers'
+
   contraction = "Can't and Won't"
   cyrillic = 'Bratʹi︠a︡ Karamazovy'
   before(:all) do
     delete_all
-    @@solr.add({ id: 1, title_a_index: [contraction, cyrillic] })
-    @@solr.commit
+    solr.add({ id: 1, title_a_index: [contraction, cyrillic] })
+    solr.commit
   end
 
   describe 'in all_fields search (text field)' do

--- a/spec/orangelight/author_search_spec.rb
+++ b/spec/orangelight/author_search_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 require 'json'
 
 describe 'author keyword search' do
+
+  include_context 'solr_helpers'
+
   def author_query_string q
     "{!qf=$author_qf pf=$author_pf}#{q}"
   end

--- a/spec/orangelight/cjk_mapping_spec.rb
+++ b/spec/orangelight/cjk_mapping_spec.rb
@@ -5,14 +5,16 @@ docs = JSON.parse(File.read('spec/fixtures/cjk_map_solr_fixtures.json'))
 stanford_docs = JSON.parse(File.read('spec/fixtures/cjk_stanford_fixtures.json'))
 
 describe 'CJK character equivalence' do
+  include_context 'solr_helpers'
+
   def add_single_field_doc char
-    @@solr.add({ id: 1, cjk_title: char })
-    @@solr.commit
+    solr.add({ id: 1, cjk_title: char })
+    solr.commit
   end
   before(:all) do
     delete_all
-    @@solr.add(docs)
-    @@solr.commit
+    solr.add(docs)
+    solr.commit
   end
   describe 'Direct mapping check' do
     docs.each do |map|
@@ -30,8 +32,8 @@ describe 'CJK character equivalence' do
   describe 'Stanford direct mapping check' do
     before(:all) do
       delete_all
-      @@solr.add(stanford_docs)
-      @@solr.commit
+      solr.add(stanford_docs)
+      solr.commit
     end
     stanford_docs.each do |map|
       from = map['cjk_mapped_from']
@@ -109,8 +111,8 @@ describe 'CJK character equivalence' do
   end
   describe 'mapping applied to left anchor search' do
     it '国史大辞典 => 國史大辭典' do
-      @@solr.add({ id: 1, title_la: '國史大辭典' })
-      @@solr.commit
+      solr.add({ id: 1, title_la: '國史大辭典' })
+      solr.commit
       expect(solr_resp_doc_ids_only({ 'q' => '{!qf=$left_anchor_qf pf=$left_anchor_pf}国史大辞典' })).to include('1')
     end
   end

--- a/spec/orangelight/keyword_relevancy_spec.rb
+++ b/spec/orangelight/keyword_relevancy_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'json'
 
 describe 'title subfield a boost' do
+  include_context 'solr_helpers'
+
   before(:all) do
     delete_all
   end

--- a/spec/orangelight/protected_words_spec.rb
+++ b/spec/orangelight/protected_words_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'json'
 
 describe 'protected words' do
+  include_context 'solr_helpers'
+
   before(:all) do
     delete_all
   end

--- a/spec/orangelight/punctuation_tokens_spec.rb
+++ b/spec/orangelight/punctuation_tokens_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'json'
 
 describe 'stripping punctuation surrounded by whitespace' do
+  include_context 'solr_helpers'
+
   def qf_pf_string q, field
     "{!qf=$#{field}_qf pf=$#{field}_pf}#{q}"
   end

--- a/spec/orangelight/standard_no_spec.rb
+++ b/spec/orangelight/standard_no_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'json'
 
 describe 'standard no keyword search' do
+  include_context 'solr_helpers'
+
   before(:all) do
     delete_all
   end
@@ -9,8 +11,8 @@ describe 'standard no keyword search' do
     isbn_normalized = '9784103534228'
     isbn_invalid = '9791032000373'
     before(:all) do
-      @@solr.add({ id: 1, isbn_s: [isbn_normalized, isbn_invalid] })
-      @@solr.commit
+      solr.add({ id: 1, isbn_s: [isbn_normalized, isbn_invalid] })
+      solr.commit
     end
     it 'isbn is indexed' do
       expect(solr_resp_doc_ids_only({ 'q' => isbn_normalized })).to include('1')
@@ -59,8 +61,8 @@ describe 'standard no keyword search' do
     lccn_2001000002 = '2001000002'
     lccn_75425165 = '75425165'
     before(:all) do
-      @@solr.add({ id: 1, lccn_s: [lccn_75425165, lccn_2001000002, lccn_85000002] })
-      @@solr.commit
+      solr.add({ id: 1, lccn_s: [lccn_75425165, lccn_2001000002, lccn_85000002] })
+      solr.commit
     end
     it 'lccn is indexed' do
       expect(solr_resp_doc_ids_only({ 'q' => lccn_75425165 })).to include('1')

--- a/spec/orangelight/subject_search_spec.rb
+++ b/spec/orangelight/subject_search_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'json'
 
 describe 'subject keyword search' do
+  include_context 'solr_helpers'
+
   def subject_query_string q
     "{!qf=$subject_qf pf=$subject_pf}#{q}"
   end

--- a/spec/orangelight/title_search_spec.rb
+++ b/spec/orangelight/title_search_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'json'
 
 describe 'title keyword search' do
+  include_context 'solr_helpers'
+
   def title_query_string q
     "{!qf=$title_qf pf=$title_pf}#{q}"
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,57 +3,56 @@ require 'rspec-solr'
 require 'faraday'
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
-RSpec.configure do |config|
+# Use this (by calling #include_context) as you would a ruby Module,
+# to mixin these methods into an rspec context. This allows contexts
+# to access different solr instances and cores.
+RSpec.shared_context 'solr_helpers' do
 
+  def solr(host: "localhost", core: "solr/blacklight-core", dtype: "edismax", suffix: "&defType=edismax", port: 8888)
+    unless @solr
+      @solr = RSolr.connect :url => "http://#{host}:#{port}/#{core}", :read_timeout => 9999999 
+      #solr_config = ENV['TRAVIS'] ? YAML::load_file('config/solr.yml')["test"] : YAML::load_file('config/solr.yml')["dev"]
+      #@@solr = RSolr.connect(solr_config)
+      puts "Solr URL: #{@solr.uri}"
+    end
+    @solr
+  end
 
-  host = "localhost"
-  core = "solr/blacklight-core"
-  dtype = "edismax"
-  suffix = "&defType=edismax"
-  prt = 8888
+  # send a GET request to the default Solr request handler with the indicated Solr parameters
+  # @param solr_params [Hash] the key/value pairs to be sent to Solr as HTTP parameters, in addition to 
+  #  those to get only id fields and no facets in the response
+  # @return [RSpecSolr::SolrResponseHash] object for rspec-solr testing the Solr response 
+  def solr_resp_doc_ids_only(solr_params)
+    solr_response(solr_params.merge(doc_ids_only))
+  end
 
+  # use these Solr HTTP params to reduce the size of the Solr responses
+  # response documents will only have id fields, and there will be no facets in the response
+  # @return [Hash] Solr HTTP params to reduce the size of the Solr responses
+  def doc_ids_only
+    {'fl'=>'id', 'facet'=>'false'}
+  end
 
-  @@solr = RSolr.connect :url => "http://#{host}:#{prt}/#{core}", :read_timeout => 9999999 
-  #solr_config = ENV['TRAVIS'] ? YAML::load_file('config/solr.yml')["test"] : YAML::load_file('config/solr.yml')["dev"]
-  #@@solr = RSolr.connect(solr_config)
-  puts "Solr URL: #{@@solr.uri}"
+  # delete all Solr documents
+  def delete_all
+    solr.delete_by_query('*:*')
+    solr.commit
+  end
 
-end
+  # gets solr doc from bibdata
+  def add_doc(id)
+    doc = JSON.parse(File.read(File.expand_path("../fixtures/#{id}.json", __FILE__)))
+    solr.add(doc)
+    solr.commit
+  end
 
-# send a GET request to the default Solr request handler with the indicated Solr parameters
-# @param solr_params [Hash] the key/value pairs to be sent to Solr as HTTP parameters, in addition to 
-#  those to get only id fields and no facets in the response
-# @return [RSpecSolr::SolrResponseHash] object for rspec-solr testing the Solr response 
-def solr_resp_doc_ids_only(solr_params)
-  solr_response(solr_params.merge(doc_ids_only))
-end
+  private
 
-# use these Solr HTTP params to reduce the size of the Solr responses
-# response documents will only have id fields, and there will be no facets in the response
-# @return [Hash] Solr HTTP params to reduce the size of the Solr responses
-def doc_ids_only
-  {'fl'=>'id', 'facet'=>'false'}
-end
-
-# delete all Solr documents
-def delete_all
-  @@solr.delete_by_query('*:*')
-  @@solr.commit
-end
-
-# gets solr doc from bibdata
-def add_doc(id)
-  doc = JSON.parse(File.read(File.expand_path("../fixtures/#{id}.json", __FILE__)))
-  @@solr.add(doc)
-  @@solr.commit
-end
-
-private
-
-# send a GET request to the indicated Solr request handler with the indicated Solr parameters
-# @param solr_params [Hash] the key/value pairs to be sent to Solr as HTTP parameters
-# @param req_handler [String] the pathname of the desired Solr request handler (defaults to 'select') 
-# @return [RSpecSolr::SolrResponseHash] object for rspec-solr testing the Solr response 
-def solr_response(solr_params, req_handler='select')  
-  RSpecSolr::SolrResponseHash.new(@@solr.send_and_receive(req_handler, {:method => :get, :params => solr_params}))
+  # send a GET request to the indicated Solr request handler with the indicated Solr parameters
+  # @param solr_params [Hash] the key/value pairs to be sent to Solr as HTTP parameters
+  # @param req_handler [String] the pathname of the desired Solr request handler (defaults to 'select') 
+  # @return [RSpecSolr::SolrResponseHash] object for rspec-solr testing the Solr response 
+  def solr_response(solr_params, req_handler='select')  
+    RSpecSolr::SolrResponseHash.new(solr.send_and_receive(req_handler, {:method => :get, :params => solr_params}))
+  end
 end


### PR DESCRIPTION
Hi! We at Penn enjoyed the impromptu presentation on this repo by @tampakis at the Blacklight Summit last week. We're currently trying to build on your excellent work for our own Solr schemas, and ran into the issue of not being to access different Solr cores/instances because of the way spec_helper.rb was written. 

This is a simple refactor to allow you to override the default Solr instance used. Here's some sample code that uses it:

```ruby
require 'spec_helper'
require 'json'

describe 'sample tests' do
  include_context 'solr_helpers'

  before(:all) do
    # here's the override
    solr(core: "solr/pulmap")
    delete_all
  end
  describe 'sample field' do
    it 'does something appropriate' do
      # use methods as you normally would
      expect(solr_resp_doc_ids_only(...)).to include(...)
    end
  end
  after(:all) do
    delete_all
  end
end
```

Just sending this PR along in the spirit of sharing, but if you are already working on achieving this some other way, please feel free to close.
