### PR TITLE
remove bigram filter in exact search field

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rspec-solr'
 
 gem 'rsolr'
 
-gem 'solr_wrapper', '~> 0.13'
+gem 'solr_wrapper', '~> 0.23'
 
 gem 'faraday'
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ solr_home_path = 'solr_configs'
 SolrWrapper.default_instance_options = {
     verbose: true,
     port: '8888',
-    version: '6.2.1',
+    version: '6.5.0',
     instance_dir: solr_instance_path,
     download_dir: solr_download_path,
     solr_options: {'s' => solr_home_path}

--- a/solr_configs/orangelight/conf/schema.xml
+++ b/solr_configs/orangelight/conf/schema.xml
@@ -209,7 +209,6 @@
         <filter class="solr.ICUTransformFilterFactory" id="Traditional-Simplified"/>
         <filter class="solr.ICUTransformFilterFactory" id="Katakana-Hiragana"/>
         <filter class="solr.ICUFoldingFilterFactory"/>   <!-- NFKC, case folding, diacritics removed -->
-        <filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="true" />
         <filter class="solr.PatternReplaceFilterFactory" pattern="(\p{Punct})" replacement="" replace="all" />
         <filter class="solr.TrimFilterFactory"/>
       </analyzer>

--- a/solr_configs/orangelight/conf/solrconfig.xml
+++ b/solr_configs/orangelight/conf/solrconfig.xml
@@ -262,7 +262,8 @@
       <str name="pf">
         title_245a_lr^16000
         title_245_lr^16000
-        title_a_index^15000
+        title_245_lr^14000
+        title_a_index^12000
         author_main_unstem_search^10000
         title_unstem_search^400
         title_display^400

--- a/spec/orangelight/keyword_relevancy_spec.rb
+++ b/spec/orangelight/keyword_relevancy_spec.rb
@@ -37,7 +37,7 @@ describe 'title subfield a boost' do
             .to include(sounds_like_silence_cage_in_title).before(no_such_thing_as_silence)
     end
   end
-  context 'when performing a keyword search combining author and title' do
+  context 'when performing CJK searches' do
     exact_match = '6581897'
     variant_exact_match = '1831578'
     japanese_exact_match = '3175938'
@@ -50,9 +50,13 @@ describe 'title subfield a boost' do
       add_doc(left_anchor_match)
       add_doc(non_phrase_match)
     end
-    it 'work matching 245a and author comes first' do
+    it 'records that contain non-phrase mathces appear last' do
       expect(solr_resp_doc_ids_only({ 'q' => '诗经研究', 'sort' => 'score ASC' }))
             .to include(non_phrase_match).as_first.document
+    end
+    it 'work matching full 245 as phrase comes first' do
+      expect(solr_resp_doc_ids_only({ 'q' => '诗经研究'}))
+            .to include(japanese_exact_match).as_first.document
     end
   end
   after(:all) do


### PR DESCRIPTION
Advances #29. Removes bigram filter in exact search field type and boosts left anchor in keyword search.
