### PR TITLE
Ensures that whitespace padding punctuation marks ar ensuring that whitespace padding punctuation marks are filtered during indexing and querying

### DIFF
--- a/solr_configs/orangelight/conf/schema.xml
+++ b/solr_configs/orangelight/conf/schema.xml
@@ -215,13 +215,8 @@
     </fieldType>
 
      <fieldType name="title_l" class="solr.TextField" positionIncrementGap="100" >
-<!--        <analyzer>
-         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="^(.*)$" replacement="AAAA $1" />
-         <tokenizer class="solr.PatternTokenizerFactory" pattern="$$$^"/>
-         <filter class="solr.ICUFoldingFilterFactory" />
-         <filter class="solr.SnowballPorterFilterFactory" language="English" />
-       </analyzer> -->
        <analyzer type="index">
+          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)" replacement="$1" />
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\p{Punct}*" replacement="" />
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[’՚Ꞌꞌ＇]" replacement="" />
           <tokenizer class="solr.KeywordTokenizerFactory" />
@@ -239,6 +234,7 @@
           <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="150"/>
        </analyzer>
        <analyzer type="query">
+          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)" replacement="$1" />
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\p{Punct}*" replacement="" />
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[’՚Ꞌꞌ＇]" replacement="" />
           <tokenizer class="solr.KeywordTokenizerFactory"/>

--- a/spec/orangelight/title_search_spec.rb
+++ b/spec/orangelight/title_search_spec.rb
@@ -88,6 +88,21 @@ describe 'title keyword search' do
       expect(solr_resp_doc_ids_only({ 'q' => left_anchor_query_string('Science'), 'sort' => 'score DESC'})["response"]["docs"].last)
             .to eq({"id" => science_and_spirit})
     end
+
+    context 'with a title which includes whitespace around punctuation marks' do
+      idioms_and_colloc = '5188770'
+      before(:all) do
+        add_doc(idioms_and_colloc)
+      end
+      it 'matches titles without the whitespace' do
+        expect(solr_resp_doc_ids_only({ 'q' => left_anchor_query_string('Idioms\ and\ collocations\ \:\ corpus-based'), 'sort' => 'score DESC'})["response"]["docs"].last)
+              .to eq({"id" => idioms_and_colloc})
+
+        expect(solr_resp_doc_ids_only({ 'q' => left_anchor_query_string('Idioms\ and\ collocations\:\ corpus-based'), 'sort' => 'score DESC'})["response"]["docs"].last)
+              .to eq({"id" => idioms_and_colloc})
+      end
+    end
+
   end
   after(:all) do
     delete_all


### PR DESCRIPTION
Resolves #50 and https://github.com/pulibrary/orangelight/issues/1101