### PR TITLE
Preventing 'musicals' from being stemmed to 'music' or 'musical'

### DIFF
--- a/solr_configs/orangelight/conf/protwords.txt
+++ b/solr_configs/orangelight/conf/protwords.txt
@@ -20,3 +20,5 @@ bible
 oversize
 overseer
 populism
+musical
+musicals

--- a/solr_configs/orangelight_staging/conf/protwords.txt
+++ b/solr_configs/orangelight_staging/conf/protwords.txt
@@ -20,3 +20,5 @@ bible
 oversize
 overseer
 populism
+musical
+musicals


### PR DESCRIPTION
Fixes #55 