### PR TITLE
Ensuring that the default values for @preserveOriginal and @stemEnglishPossessive are overridden for WordDelimiterGraphFilterFactory

### DIFF
--- a/solr_configs/orangelight/conf/schema.xml
+++ b/solr_configs/orangelight/conf/schema.xml
@@ -221,7 +221,7 @@
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)" replacement="$1" />
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\p{Punct}^[‒–—―])*" replacement="" />
           <!-- Filters for the entire string -->
-          <filter class="solr.WordDelimiterGraphFilterFactory" />
+          <filter class="solr.WordDelimiterGraphFilterFactory" preserveOriginal="1" stemEnglishPossessive="0" />
           <filter class="solr.FlattenGraphFilterFactory"/> <!-- This is only necessary for indexing when using a *GraphFilterFactory -->
           <!-- Tokenize the string -->
           <tokenizer class="solr.KeywordTokenizerFactory" />
@@ -245,7 +245,7 @@
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)" replacement="$1" />
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\p{Punct}^[‒–—―])*" replacement="" />
           <!-- Filters for the entire string -->
-          <filter class="solr.WordDelimiterGraphFilterFactory" />
+          <filter class="solr.WordDelimiterGraphFilterFactory" preserveOriginal="1" stemEnglishPossessive="0" />
           <!-- Tokenize the string -->
           <tokenizer class="solr.KeywordTokenizerFactory"/>
           <!-- Handle non-Latin orthographies -->

--- a/solr_configs/orangelight_staging/conf/schema.xml
+++ b/solr_configs/orangelight_staging/conf/schema.xml
@@ -221,7 +221,7 @@
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)" replacement="$1" />
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\p{Punct}^[‒–—―])*" replacement="" />
           <!-- Filters for the entire string -->
-          <filter class="solr.WordDelimiterGraphFilterFactory" />
+          <filter class="solr.WordDelimiterGraphFilterFactory" preserveOriginal="1" stemEnglishPossessive="0" />
           <filter class="solr.FlattenGraphFilterFactory"/> <!-- This is only necessary for indexing when using a *GraphFilterFactory -->
           <!-- Tokenize the string -->
           <tokenizer class="solr.KeywordTokenizerFactory" />
@@ -245,7 +245,7 @@
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)" replacement="$1" />
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\p{Punct}^[‒–—―])*" replacement="" />
           <!-- Filters for the entire string -->
-          <filter class="solr.WordDelimiterGraphFilterFactory" />
+          <filter class="solr.WordDelimiterGraphFilterFactory" preserveOriginal="1" stemEnglishPossessive="0" />
           <!-- Tokenize the string -->
           <tokenizer class="solr.KeywordTokenizerFactory"/>
           <!-- Handle non-Latin orthographies -->


### PR DESCRIPTION
Properly resolves https://github.com/pulibrary/orangelight/issues/1184

This was originally provided by @tampakis in https://github.com/pulibrary/pul_solr/pull/57#issuecomment-373471534