### PR TITLE
[WIP] Escapes ':' when using search with title_l field in orangelight production and staging.

### DIFF
--- a/solr_configs/orangelight/conf/schema.xml
+++ b/solr_configs/orangelight/conf/schema.xml
@@ -218,7 +218,7 @@
        <analyzer type="index">
           <!-- Filters for individual characters -->
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[ʹ’՚Ꞌꞌ' ︠	︡]" replacement="" />
-          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)" replacement="$1" />
+          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\:\s+(\p{Punct}+)" replacement="$1" />
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\p{Punct}^[‒–—―])*" replacement="" />
           <!-- Filters for the entire string -->
           <filter class="solr.WordDelimiterGraphFilterFactory" preserveOriginal="1" stemEnglishPossessive="0" />

--- a/solr_configs/orangelight_staging/conf/schema.xml
+++ b/solr_configs/orangelight_staging/conf/schema.xml
@@ -218,7 +218,7 @@
        <analyzer type="index">
           <!-- Filters for individual characters -->
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[ʹ’՚Ꞌꞌ' ︠	︡]" replacement="" />
-          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+(\p{Punct}+)" replacement="$1" />
+          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\:\s+(\p{Punct}+)" replacement="$1" />
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\p{Punct}^[‒–—―])*" replacement="" />
           <!-- Filters for the entire string -->
           <filter class="solr.WordDelimiterGraphFilterFactory" preserveOriginal="1" stemEnglishPossessive="0" />


### PR DESCRIPTION
Escapes ':' when using search with title_l field in orangelight production and staging.