### PR TITLE
reimplements left-anchor search to avoid n-grams

### DIFF
--- a/solr_configs/orangelight/conf/schema.xml
+++ b/solr_configs/orangelight/conf/schema.xml
@@ -215,39 +215,15 @@
     </fieldType>
 
      <fieldType name="title_l" class="solr.TextField" positionIncrementGap="100" >
-       <analyzer type="index">
+       <analyzer>
           <!-- Filters for individual characters -->
-          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[ʹ’՚Ꞌꞌ' ︠	︡]" replacement="" />
-          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\:\s+(\p{Punct}+)" replacement="$1" />
-          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\p{Punct}^[‒–—―])*" replacement="" />
-          <!-- Filters for the entire string -->
-          <filter class="solr.WordDelimiterGraphFilterFactory" catenateWords="1" generateWordParts="1" preserveOriginal="1" stemEnglishPossessive="0" />
-          <filter class="solr.FlattenGraphFilterFactory"/> <!-- This is only necessary for indexing when using a *GraphFilterFactory -->
+          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[ʹ’՚Ꞌꞌ']" replacement="" />
+          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\p{Punct}" replacement="" />
+          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\s+" replacement=" " />
           <!-- Tokenize the string -->
           <tokenizer class="solr.KeywordTokenizerFactory" />
-          <!-- Handle non-Latin orthographies -->
-          <filter class="solr.ICUFoldingFilterFactory" />
-          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="０" replacement="〇" />
-          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\p{InHangul_Jamo}\p{InHangul_Compatibility_Jamo}\p{InHangul_Syllables}][\p{InBopomofo}\p{InBopomofo_Extended}\p{InCJK_Compatibility}\p{InCJK_Compatibility_Forms}\p{InCJK_Compatibility_Ideographs}\p{InCJK_Compatibility_Ideographs_Supplement}\p{InCJK_Radicals_Supplement}\p{InCJK_Symbols_And_Punctuation}\p{InCJK_Unified_Ideographs}\p{InCJK_Unified_Ideographs_Extension_A}\p{InCJK_Unified_Ideographs_Extension_B}\p{InKangxi_Radicals}\p{InHalfwidth_And_Fullwidth_Forms}\p{InIdeographic_Description_Characters}]*)\s+(?=[\p{InHangul_Jamo}\p{InHangul_Compatibility_Jamo}\p{InHangul_Syllables}\p{InBopomofo}\p{InBopomofo_Extended}\p{InCJK_Compatibility}\p{InCJK_Compatibility_Forms}\p{InCJK_Compatibility_Ideographs}\p{InCJK_Compatibility_Ideographs_Supplement}\p{InCJK_Radicals_Supplement}\p{InCJK_Symbols_And_Punctuation}\p{InCJK_Unified_Ideographs}\p{InCJK_Unified_Ideographs_Extension_A}\p{InCJK_Unified_Ideographs_Extension_B}\p{InKangxi_Radicals}\p{InHalfwidth_And_Fullwidth_Forms}\p{InIdeographic_Description_Characters}])" replacement="$1"/>
-          <!-- a korean char guaranteed at the end of the pattern:    pattern="([\p{Hangul}\p{Han}])\s+(?=[\p{Han}\s]*\p{Hangul})" -->
-          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\p{InHangul_Jamo}\p{InHangul_Compatibility_Jamo}\p{InHangul_Syllables}\p{InBopomofo}\p{InBopomofo_Extended}\p{InCJK_Compatibility}\p{InCJK_Compatibility_Forms}\p{InCJK_Compatibility_Ideographs}\p{InCJK_Compatibility_Ideographs_Supplement}\p{InCJK_Radicals_Supplement}\p{InCJK_Symbols_And_Punctuation}\p{InCJK_Unified_Ideographs}\p{InCJK_Unified_Ideographs_Extension_A}\p{InCJK_Unified_Ideographs_Extension_B}\p{InKangxi_Radicals}\p{InHalfwidth_And_Fullwidth_Forms}\p{InIdeographic_Description_Characters}])\s+(?=[\p{InBopomofo}\p{InBopomofo_Extended}\p{InCJK_Compatibility}\p{InCJK_Compatibility_Forms}\p{InCJK_Compatibility_Ideographs}\p{InCJK_Compatibility_Ideographs_Supplement}\p{InCJK_Radicals_Supplement}\p{InCJK_Symbols_And_Punctuation}\p{InCJK_Unified_Ideographs}\p{InCJK_Unified_Ideographs_Extension_A}\p{InCJK_Unified_Ideographs_Extension_B}\p{InKangxi_Radicals}\p{InHalfwidth_And_Fullwidth_Forms}\p{InIdeographic_Description_Characters}\s]*[\p{InHangul_Jamo}\p{InHangul_Compatibility_Jamo}\p{InHangul_Syllables}])" replacement="$1"/>
-          <filter class="solr.CJKWidthFilterFactory"/>
-          <filter class="edu.stanford.lucene.analysis.CJKFoldingFilterFactory"/>
-          <filter class="solr.ICUTransformFilterFactory" id="Traditional-Simplified"/>
-          <filter class="solr.ICUTransformFilterFactory" id="Katakana-Hiragana"/>
-          <filter class="solr.ICUFoldingFilterFactory"/>   <!-- NFKC, case folding, diacritics removed -->
-          <filter class="solr.CJKBigramFilterFactory" han="true" hiragana="true" katakana="true" hangul="true" outputUnigrams="true" />
-          <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="150"/>
-       </analyzer>
-       <analyzer type="query">
-          <!-- Filters for individual characters -->
-          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="[ʹ’՚Ꞌꞌ' ︠	︡]" replacement="" />
-          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="\:\s+(\p{Punct}+)" replacement="$1" />
-          <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(\p{Punct}^[‒–—―])*" replacement="" />
-          <!-- Filters for the entire string -->
-          <filter class="solr.WordDelimiterGraphFilterFactory" catenateWords="1" generateWordParts="1" preserveOriginal="1" stemEnglishPossessive="0" />
-          <!-- Tokenize the string -->
-          <tokenizer class="solr.KeywordTokenizerFactory"/>
+          <!-- Remove trailing and leading spaces -->
+          <filter class="solr.TrimFilterFactory"/>
           <!-- Handle non-Latin orthographies -->
           <filter class="solr.ICUFoldingFilterFactory" />
           <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="０" replacement="〇" />

--- a/spec/orangelight/apostrophe_spec.rb
+++ b/spec/orangelight/apostrophe_spec.rb
@@ -68,7 +68,7 @@ describe 'apostrophes are stripped' do
 
   describe 'in left_anchor search' do
     let(:params) do
-      { 'q' => "{!qf=$left_anchor_qf pf=$left_anchor_pf}can’t" }
+      { 'q' => "{!qf=$left_anchor_qf pf=$left_anchor_pf}can’t*" }
     end
     let(:response) { solr_resp_doc_ids_only(params)['response'] }
     let(:docs) { response['docs'] }
@@ -79,7 +79,7 @@ describe 'apostrophes are stripped' do
 
     context 'when apostrophe excluded in query for contraction' do
       let(:params) do
-        { 'q' => '{!qf=$left_anchor_qf pf=$left_anchor_pf}cant' }
+        { 'q' => '{!qf=$left_anchor_qf pf=$left_anchor_pf}cant*' }
       end
 
       it 'matches' do


### PR DESCRIPTION
Reimplements left-anchor search field to avoid using n-grams. The search expects wildcard to be added to the end of the query, which will be sent from the catalog app. In changing the config, also resolves an issue where non left-anchor searches would match (queries that don't include the first word of the title but includes a substring of the title).

The new implementation decreases the size of the index by about 40% which should lessen memory needs for solr.