### PR TITLE
Adds cjk mapping for advanced search fields

### DIFF
--- a/solr_configs/orangelight/conf/schema.xml
+++ b/solr_configs/orangelight/conf/schema.xml
@@ -813,6 +813,16 @@
 
    <copyField source="more_in_this_series_t" dest="more_in_this_series_la"/>
 
+   <!-- advanced search fields cjk config -->
+   <copyField source="series_title_index" dest="cjk_series_title"/>
+   <copyField source="series_ae_index" dest="cjk_series_title"/>
+   <copyField source="series_statement_index" dest="cjk_series_title"/>
+   <copyField source="linked_series_title_index" dest="cjk_series_title"/>
+   <copyField source="linked_series_index" dest="cjk_series_title"/>
+   <copyField source="original_version_series_index" dest="cjk_series_title"/>
+   <copyField source="notes_index" dest="cjk_notes"/>
+   <copyField source="pub_created_unstem_search" dest="cjk_publisher"/>
+
    <!-- Above, multiple source fields are copied to the [text] field.
     Another way to map multiple source fields to the same
     destination field is to use the dynamic field syntax.

--- a/solr_configs/orangelight/conf/solrconfig.xml
+++ b/solr_configs/orangelight/conf/solrconfig.xml
@@ -329,6 +329,22 @@
       <str name="in_series_pf">
         more_in_this_series_la
       </str>
+      <str name="publisher_qf">
+        pub_created_unstem_search
+        cjk_publisher
+      </str>
+      <str name="publisher_pf">
+        pub_created_unstem_search
+        cjk_publisher
+      </str>
+      <str name="notes_qf">
+        notes_index
+        cjk_notes
+      </str>
+      <str name="notes_pf">
+        notes_index
+        cjk_notes
+      </str>
       <str name="series_title_qf">
         series_title_index^5
         series_ae_index
@@ -336,6 +352,7 @@
         linked_series_title_index
         linked_series_index
         original_version_series_index
+        cjk_series_title
       </str>
       <str name="series_title_pf">
         series_title_index^50
@@ -344,6 +361,7 @@
         linked_series_title_index^10
         linked_series_index^10
         original_version_series_index^10
+        cjk_series_title^10
       </str>
       <str name="title_qf">
         title_a_index^500

--- a/solr_configs/orangelight/conf/solrconfig_replication.xml
+++ b/solr_configs/orangelight/conf/solrconfig_replication.xml
@@ -57,7 +57,7 @@
          If it is 'internal' everything will be taken care of automatically.
          USE THIS ONLY IF YOUR BANDWIDTH IS LOW.
          THIS CAN ACTUALLY SLOWDOWN REPLICATION IN A LAN -->
-    <str name="pollInterval">00:00:20</str>     
+    <str name="pollInterval">00:04:00</str>
     <str name="compression">internal</str>
 
     <!-- The following values are used when the slave connects to the master to
@@ -350,6 +350,22 @@
       <str name="in_series_pf">
         more_in_this_series_la
       </str>
+      <str name="publisher_qf">
+        pub_created_unstem_search
+        cjk_publisher
+      </str>
+      <str name="publisher_pf">
+        pub_created_unstem_search
+        cjk_publisher
+      </str>
+      <str name="notes_qf">
+        notes_index
+        cjk_notes
+      </str>
+      <str name="notes_pf">
+        notes_index
+        cjk_notes
+      </str>
       <str name="series_title_qf">
         series_title_index^5
         series_ae_index
@@ -357,6 +373,7 @@
         linked_series_title_index
         linked_series_index
         original_version_series_index
+        cjk_series_title
       </str>
       <str name="series_title_pf">
         series_title_index^50
@@ -365,6 +382,7 @@
         linked_series_title_index^10
         linked_series_index^10
         original_version_series_index^10
+        cjk_series_title^10
       </str>
       <str name="title_qf">
         title_a_index^500

--- a/spec/orangelight/cjk_mapping_spec.rb
+++ b/spec/orangelight/cjk_mapping_spec.rb
@@ -109,13 +109,29 @@ describe 'CJK character equivalence' do
       expect(solr_resp_doc_ids_only({ 'fq'=>'cjk_title:"梅亜"' })).to include('1')
     end
   end
-  describe 'mapping applied to left anchor search' do
-    it '国史大辞典 => 國史大辭典' do
+  describe 'mapping applied to search fields' do
+    it '国史大辞典 => 國史大辭典 left anchor' do
       solr.add({ id: 1, title_la: '國史大辭典' })
       solr.commit
       expect(solr_resp_doc_ids_only({ 'q' => '{!qf=$left_anchor_qf pf=$left_anchor_pf}国史大辞典' })).to include('1')
     end
+    it '三晋出版社 => 三晉出版社 publisher' do
+      solr.add({ id: 1, pub_created_unstem_search: '三晋出版社' })
+      solr.commit
+      expect(solr_resp_doc_ids_only({ 'q' => '{!qf=$publisher_qf pf=$publisher_pf}三晉出版社' })).to include('1')
+    end
+    it '巴蜀書社 => 巴蜀书社  notes' do
+      solr.add({ id: 1, notes_index: '巴蜀書社' })
+      solr.commit
+      expect(solr_resp_doc_ids_only({ 'q' => '{!qf=$notes_qf pf=$notes_pf}巴蜀书社 ' })).to include('1')
+    end
+    it '鳳凰出版社 => 凤凰出版社  series title' do
+      solr.add({ id: 1, original_version_series_index: '鳳凰出版社' })
+      solr.commit
+      expect(solr_resp_doc_ids_only({ 'q' => '{!qf=$series_title_qf pf=$series_title_pf}凤凰出版社 ' })).to include('1')
+    end
   end
+
   after(:all) do
     delete_all
   end


### PR DESCRIPTION
Adds cjk mapping for notes, publisher, and series title search fields. Closes pulibrary/orangelight#1284.