### PR TITLE
Solr 7.1 deprecations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ solr_home_path = 'solr_configs'
 SolrWrapper.default_instance_options = {
     verbose: true,
     port: '8888',
-    version: '7.0.0',
+    version: '7.1.0',
     instance_dir: solr_instance_path,
     download_dir: solr_download_path,
     solr_options: {'s' => solr_home_path}

--- a/solr_configs/dpul-blacklight/conf/managed-schema
+++ b/solr_configs/dpul-blacklight/conf/managed-schema
@@ -18,7 +18,7 @@
     </analyzer>
   </fieldType>
   <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
-  <fieldType name="date" class="solr.TrieDateField" positionIncrementGap="0" precisionStep="0"/>
+  <fieldType name="date" class="solr.DatePointField"/>
   <fieldType name="descendent_path" class="solr.TextField">
     <analyzer type="index">
       <tokenizer class="solr.PathHierarchyTokenizerFactory" delimiter="/"/>
@@ -27,12 +27,12 @@
       <tokenizer class="solr.KeywordTokenizerFactory"/>
     </analyzer>
   </fieldType>
-  <fieldType name="double" class="solr.TrieDoubleField" positionIncrementGap="0" precisionStep="0"/>
-  <fieldType name="float" class="solr.TrieFloatField" positionIncrementGap="0" precisionStep="0"/>
-  <fieldType name="int" class="solr.TrieIntField" positionIncrementGap="0" precisionStep="0"/>
-  <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
+  <fieldType name="double" class="solr.DoublePointField"/>
+  <fieldType name="float" class="solr.FloatPointField"/>
+  <fieldType name="int" class="solr.IntPointField"/>
+  <fieldType name="location" class="solr.LatLonPointSpatialField"/>
   <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType" geo="true" maxDistErr="0.000009" distErrPct="0.025" distanceUnits="degrees"/>
-  <fieldType name="long" class="solr.TrieLongField" positionIncrementGap="0" precisionStep="0"/>
+  <fieldType name="long" class="solr.LongPointField"/>
   <fieldType name="pid_text" class="solr.TextField" positionIncrementGap="100">
     <analyzer>
       <tokenizer class="solr.KeywordTokenizerFactory"/>
@@ -41,8 +41,8 @@
   <fieldType name="point" class="solr.PointType" subFieldSuffix="_d" dimension="2"/>
   <fieldType name="rand" class="solr.RandomSortField" omitNorms="true"/>
   <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
-  <fieldType name="tdate" class="solr.TrieDateField" positionIncrementGap="0" precisionStep="6"/>
-  <fieldType name="tdouble" class="solr.TrieDoubleField" positionIncrementGap="0" precisionStep="8"/>
+  <fieldType name="tdate" class="solr.DatePointField"/>
+  <fieldType name="tdouble" class="solr.DoublePointField"/>
   <fieldType name="text" class="solr.TextField" omitNorms="false">
     <analyzer>
       <tokenizer class="solr.ICUTokenizerFactory"/>
@@ -75,9 +75,9 @@
       <filter class="solr.TrimFilterFactory"/>
     </analyzer>
   </fieldType>
-  <fieldType name="tfloat" class="solr.TrieFloatField" positionIncrementGap="0" precisionStep="8"/>
-  <fieldType name="tint" class="solr.TrieIntField" positionIncrementGap="0" precisionStep="8"/>
-  <fieldType name="tlong" class="solr.TrieLongField" positionIncrementGap="0" precisionStep="8"/>
+  <fieldType name="tfloat" class="solr.FloatPointField"/>
+  <fieldType name="tint" class="solr.IntPointField"/>
+  <fieldType name="tlong" class="solr.LongPointField"/>
   <field name="_version_" type="long" indexed="true" stored="true"/>
   <field name="all_text_timv" type="text" indexed="true" termOffsets="true" stored="false" termPositions="true" termVectors="true" multiValued="true"/>
   <field name="full_title_ng" type="text_en_ng" multiValued="true" indexed="true" stored="false"/>

--- a/solr_configs/dpul-blacklight/conf/schema.xml
+++ b/solr_configs/dpul-blacklight/conf/schema.xml
@@ -213,23 +213,23 @@
     <fieldType name="rand" class="solr.RandomSortField" omitNorms="true"/>
     
     <!-- Default numeric field types.  -->
-    <fieldType name="int" class="solr.TrieIntField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="int" class="solr.IntPointField"/>
+    <fieldType name="float" class="solr.FloatPointField"/>
+    <fieldType name="long" class="solr.LongPointField"/>
+    <fieldType name="double" class="solr.DoublePointField"/>
     
     <!-- trie numeric field types for faster range queries -->
-    <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0"/>
+    <fieldType name="tint" class="solr.IntPointField"/>
+    <fieldType name="tfloat" class="solr.FloatPointField"/>
+    <fieldType name="tlong" class="solr.LongPointField"/>
+    <fieldType name="tdouble" class="solr.DoublePointField"/>
     
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
       -->
-    <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="date" class="solr.DatePointField"/>
     <!-- A Trie based date field for faster date range queries and date faceting. -->
-    <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
+    <fieldType name="tdate" class="solr.DatePointField"/>
     
     
     <!-- This point type indexes the coordinates as separate fields (subFields)
@@ -246,7 +246,7 @@
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
     
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
+    <fieldType name="location" class="solr.LatLonPointSpatialField"/>
     
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:
@@ -346,4 +346,3 @@
   </types>
   
 </schema>
-

--- a/solr_configs/dpul-blacklight/conf/solrconfig.xml
+++ b/solr_configs/dpul-blacklight/conf/solrconfig.xml
@@ -23,11 +23,11 @@
   <dataDir>${solr.data.dir:}</dataDir>
 
   <requestHandler name="/replication" class="solr.ReplicationHandler">
+    <str name="commitReserveDuration">00:00:10</str>
     <lst name="master">
       <str name="replicateAfter">commit</str>
       <str name="backupAfter">optimize</str>
       <str name="confFiles">solrconfig_replication.xml:solrconfig.xml</str>
-      <str name="commitReserveDuration">00:00:10</str>
     </lst>
     <int name="maxNumberOfBackups">1</int>
     <lst name="invariants">

--- a/solr_configs/figgy/conf/schema.xml
+++ b/solr_configs/figgy/conf/schema.xml
@@ -63,23 +63,23 @@
     <fieldType name="rand" class="solr.RandomSortField" omitNorms="true"/>
     
     <!-- Default numeric field types.  -->
-    <fieldType name="int" class="solr.TrieIntField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>
-    <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="int" class="solr.IntPointField"/>
+    <fieldType name="float" class="solr.FloatPointField"/>
+    <fieldType name="long" class="solr.LongPointField"/>
+    <fieldType name="double" class="solr.DoublePointField"/>
     
     <!-- trie numeric field types for faster range queries -->
-    <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" positionIncrementGap="0"/>
+    <fieldType name="tint" class="solr.IntPointField"/>
+    <fieldType name="tfloat" class="solr.FloatPointField"/>
+    <fieldType name="tlong" class="solr.LongPointField"/>
+    <fieldType name="tdouble" class="solr.DoublePointField"/>
     
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z
          Optional fractional seconds are allowed: 1995-12-31T23:59:59.999Z
       -->
-    <fieldType name="date" class="solr.TrieDateField" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="date" class="solr.DatePointField"/>
     <!-- A Trie based date field for faster date range queries and date faceting. -->
-    <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
+    <fieldType name="tdate" class="solr.DatePointField"/>
     
     
     <!-- This point type indexes the coordinates as separate fields (subFields)
@@ -96,7 +96,7 @@
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
     
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
+    <fieldType name="location" class="solr.LatLonPointSpatialField"/>
     
     <!-- An alternative geospatial field type new to Solr 4.  It supports multiValued and polygon shapes.
       For more information about this and other Spatial fields new to Solr 4, see:
@@ -337,8 +337,6 @@
  <!-- field for the QueryParser to use when an explicit fieldname is absent -->
  <!--  <defaultSearchField>text</defaultSearchField> -->
 
- <!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
-
   <!-- copyField commands copy one field to another at the time a document
         is added to the index.  It's used either to index the same field differently,
         or to add multiple fields to the same field for easier/faster searching.  -->
@@ -351,10 +349,8 @@
 
    <!-- <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/> -->
    <!-- for suggestions -->
-   <!--
    <copyField source="*_tesim" dest="suggest"/>
    <copyField source="*_ssim" dest="suggest"/>
-   -->
 
  <!-- Similarity is the scoring routine for each document vs. a query.
       A custom similarity may be specified here, but the default is fine

--- a/solr_configs/figgy/conf/solrconfig.xml
+++ b/solr_configs/figgy/conf/solrconfig.xml
@@ -45,11 +45,11 @@
   <dataDir>${solr.figgy-core.data.dir:}</dataDir>
   
   <requestHandler name="/replication" class="solr.ReplicationHandler">
+    <str name="commitReserveDuration">00:00:10</str>
     <lst name="master">
       <str name="replicateAfter">commit</str>
       <str name="backupAfter">optimize</str>
       <str name="confFiles">solrconfig_replication.xml:solrconfig.xml</str>
-      <str name="commitReserveDuration">00:00:10</str>
     </lst>
     <int name="maxNumberOfBackups">1</int>
     <lst name="invariants">

--- a/solr_configs/lae-blacklight/conf/schema.xml
+++ b/solr_configs/lae-blacklight/conf/schema.xml
@@ -93,10 +93,10 @@
     <!--
       Default numeric field types. For faster range queries, consider the tint/tfloat/tlong/tdouble types.
     -->
-    <fieldType name="int" class="solr.TrieIntField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="long" class="solr.TrieLongField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="int" class="solr.IntPointField"/>
+    <fieldType name="float" class="solr.FloatPointField"/>
+    <fieldType name="long" class="solr.LongPointField"/>
+    <fieldType name="double" class="solr.DoublePointField"/>
 
     <!--
      Numeric field types that index each value at various levels of precision
@@ -108,10 +108,10 @@
      indexed per value, slightly larger index size, and faster range queries.
      A precisionStep of 0 disables indexing at different precision levels.
     -->
-    <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="tint" class="solr.IntPointField"/>
+    <fieldType name="tfloat" class="solr.FloatPointField"/>
+    <fieldType name="tlong" class="solr.LongPointField"/>
+    <fieldType name="tdouble" class="solr.DoublePointField"/>
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
@@ -135,10 +135,10 @@
 
          Note: For faster range queries, consider the tdate type
       -->
-    <fieldType name="date" class="solr.TrieDateField" omitNorms="true" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="date" class="solr.DatePointField" omitNorms="true"/>
 
     <!-- A Trie based date field for faster date range queries and date faceting. -->
-    <fieldType name="tdate" class="solr.TrieDateField" omitNorms="true" precisionStep="6" positionIncrementGap="0"/>
+    <fieldType name="tdate" class="solr.DatePointField" omitNorms="true"/>
 
     <!-- One can also specify an existing Analyzer class that has a
          default constructor via the class attribute on the analyzer element
@@ -164,7 +164,7 @@
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="lang/stopwords_en.txt" />
-        <filter class="solr.WordDelimiterFilterFactory"
+        <filter class="solr.WordDelimiterGraphFilterFactory"
                 generateWordParts="1" generateNumberParts="1" 
                 catenateWords="1" catenateNumbers="1" 
                 catenateAll="0" splitOnCaseChange="1"/>
@@ -185,7 +185,7 @@
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="lang/stopwords_es.txt" />
-        <filter class="solr.WordDelimiterFilterFactory"
+        <filter class="solr.WordDelimiterGraphFilterFactory"
                 generateWordParts="1" generateNumberParts="1" 
                 catenateWords="1" catenateNumbers="1" 
                 catenateAll="0" splitOnCaseChange="1"/>
@@ -205,7 +205,7 @@
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="lang/stopwords_pt.txt" />
-        <filter class="solr.WordDelimiterFilterFactory"
+        <filter class="solr.WordDelimiterGraphFilterFactory"
                 generateWordParts="1" generateNumberParts="1" 
                 catenateWords="1" catenateNumbers="1" 
                 catenateAll="0" splitOnCaseChange="1"/>
@@ -223,7 +223,7 @@
         <!-- <tokenizer class="solr.WhitespaceTokenizerFactory"/> -->
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.ICUFoldingFilterFactory" />
-        <filter class="solr.WordDelimiterFilterFactory"
+        <filter class="solr.WordDelimiterGraphFilterFactory"
                 generateWordParts="1" generateNumberParts="1" 
                 catenateWords="1" catenateNumbers="1" 
                 catenateAll="0" splitOnCaseChange="1"/>
@@ -382,7 +382,6 @@
    <copyField source="date_created" dest="date_created_facet" />
    <copyField source="earliest_created" dest="date_created_facet" />
    <copyField source="date_created" dest="date_numsort" />
-   <copyField source="earliest_created" dest="date_numsort" />
    <copyField source="language_label" dest="language_label_facet"/>
    <copyField source="subject_label" dest="subject_label_facet"/>
 

--- a/solr_configs/lae-blacklight/conf/solrconfig.xml
+++ b/solr_configs/lae-blacklight/conf/solrconfig.xml
@@ -35,11 +35,11 @@
   <dataDir>${solr.blacklight-core.data.dir:}</dataDir>
   
   <requestHandler name="/replication" class="solr.ReplicationHandler">
+    <str name="commitReserveDuration">00:00:10</str>
     <lst name="master">
       <str name="replicateAfter">commit</str>
       <str name="backupAfter">optimize</str>
       <str name="confFiles">solrconfig_replication.xml:solrconfig.xml</str>
-      <str name="commitReserveDuration">00:00:10</str>
     </lst>
     <int name="maxNumberOfBackups">1</int>
     <lst name="invariants">
@@ -51,7 +51,7 @@
     <requestParsers enableRemoteStreaming="false" multipartUploadLimitInKB="2048" />
   </requestDispatcher>
   
-  <requestHandler name="standard" class="solr.StandardRequestHandler" />
+  <requestHandler name="standard" class="solr.SearchHandler" />
   <requestHandler name="/analysis/field" startup="lazy" class="solr.FieldAnalysisRequestHandler" />
   <requestHandler name="/update" class="solr.UpdateRequestHandler"  />
      

--- a/solr_configs/orangelight/conf/schema.xml
+++ b/solr_configs/orangelight/conf/schema.xml
@@ -93,10 +93,10 @@
     <!--
       Default numeric field types. For faster range queries, consider the tint/tfloat/tlong/tdouble types.
     -->
-    <fieldType name="int" class="solr.TrieIntField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="float" class="solr.TrieFloatField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="long" class="solr.TrieLongField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="double" class="solr.TrieDoubleField" precisionStep="0" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="int" class="solr.IntPointField"/>
+    <fieldType name="float" class="solr.FloatPointField"/>
+    <fieldType name="long" class="solr.LongPointField"/>
+    <fieldType name="double" class="solr.DoublePointField"/>
 
     <!--
      Numeric field types that index each value at various levels of precision
@@ -108,10 +108,10 @@
      indexed per value, slightly larger index size, and faster range queries.
      A precisionStep of 0 disables indexing at different precision levels.
     -->
-    <fieldType name="tint" class="solr.TrieIntField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tfloat" class="solr.TrieFloatField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tlong" class="solr.TrieLongField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
-    <fieldType name="tdouble" class="solr.TrieDoubleField" precisionStep="8" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="tint" class="solr.IntPointField"/>
+    <fieldType name="tfloat" class="solr.FloatPointField"/>
+    <fieldType name="tlong" class="solr.LongPointField"/>
+    <fieldType name="tdouble" class="solr.DoublePointField"/>
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z, and
          is a more restricted form of the canonical representation of dateTime
@@ -135,10 +135,10 @@
 
          Note: For faster range queries, consider the tdate type
       -->
-    <fieldType name="date" class="solr.TrieDateField" omitNorms="true" precisionStep="0" positionIncrementGap="0"/>
+    <fieldType name="date" class="solr.DatePointField" omitNorms="true"/>
 
     <!-- A Trie based date field for faster date range queries and date faceting. -->
-    <fieldType name="tdate" class="solr.TrieDateField" omitNorms="true" precisionStep="6" positionIncrementGap="0"/>
+    <fieldType name="tdate" class="solr.DatePointField" omitNorms="true"/>
 
 
     <!--
@@ -199,7 +199,8 @@
         <charFilter class="solr.PatternReplaceCharFilterFactory"
           pattern="^(.*)$" replacement="AAAA $1 ZZZZ" />
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="０" replacement="〇" />
         <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="([\p{InHangul_Jamo}\p{InHangul_Compatibility_Jamo}\p{InHangul_Syllables}][\p{InBopomofo}\p{InBopomofo_Extended}\p{InCJK_Compatibility}\p{InCJK_Compatibility_Forms}\p{InCJK_Compatibility_Ideographs}\p{InCJK_Compatibility_Ideographs_Supplement}\p{InCJK_Radicals_Supplement}\p{InCJK_Symbols_And_Punctuation}\p{InCJK_Unified_Ideographs}\p{InCJK_Unified_Ideographs_Extension_A}\p{InCJK_Unified_Ideographs_Extension_B}\p{InKangxi_Radicals}\p{InHalfwidth_And_Fullwidth_Forms}\p{InIdeographic_Description_Characters}]*)\s+(?=[\p{InHangul_Jamo}\p{InHangul_Compatibility_Jamo}\p{InHangul_Syllables}\p{InBopomofo}\p{InBopomofo_Extended}\p{InCJK_Compatibility}\p{InCJK_Compatibility_Forms}\p{InCJK_Compatibility_Ideographs}\p{InCJK_Compatibility_Ideographs_Supplement}\p{InCJK_Radicals_Supplement}\p{InCJK_Symbols_And_Punctuation}\p{InCJK_Unified_Ideographs}\p{InCJK_Unified_Ideographs_Extension_A}\p{InCJK_Unified_Ideographs_Extension_B}\p{InKangxi_Radicals}\p{InHalfwidth_And_Fullwidth_Forms}\p{InIdeographic_Description_Characters}])" replacement="$1"/>
           <!-- a korean char guaranteed at the end of the pattern:    pattern="([\p{Hangul}\p{Han}])\s+(?=[\p{Han}\s]*\p{Hangul})" -->
@@ -260,15 +261,12 @@
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.ICUFoldingFilterFactory" />
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        -->
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
         <filter class="solr.ICUFoldingFilterFactory" />
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
     </fieldType>
@@ -281,9 +279,6 @@
     <fieldType name="text_en" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        -->
         <!-- Case insensitive stop word removal.
           add enablePositionIncrements=true in both the index and query
           analyzers to leave a 'gap' for more accurate phrase queries.
@@ -302,7 +297,7 @@
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="stopwords_en.txt"
@@ -320,7 +315,7 @@
     <!-- A text field with defaults appropriate for English, plus
    aggressive word-splitting and autophrase features enabled.
    This field is just like text_en, except it adds
-   WordDelimiterFilter to enable splitting and matching of
+   WordDelimiterGraphFilterFactory to enable splitting and matching of
    words on case-change, alpha numeric boundaries, and
    non-alphanumeric chars.  This means certain compound word
    cases will work, for example query "wi fi" will match
@@ -332,9 +327,6 @@
     <fieldType name="text_en_splitting" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
       <analyzer type="index">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <!-- in this example, we will only use synonyms at query time
-        <filter class="solr.SynonymFilterFactory" synonyms="index_synonyms.txt" ignoreCase="true" expand="false"/>
-        -->
         <!-- Case insensitive stop word removal.
           add enablePositionIncrements=true in both the index and query
           analyzers to leave a 'gap' for more accurate phrase queries.
@@ -343,19 +335,19 @@
                 ignoreCase="true"
                 words="stopwords_en.txt"
                 />
-        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
         <filter class="solr.PorterStemFilterFactory"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory"
                 ignoreCase="true"
                 words="stopwords_en.txt"
                 />
-        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
         <filter class="solr.PorterStemFilterFactory"/>
@@ -367,14 +359,15 @@
     <fieldType name="text_en_splitting_tight" class="solr.TextField" positionIncrementGap="100" autoGeneratePhraseQueries="true">
       <analyzer>
         <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="false"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt"/>
-        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="0" generateNumberParts="0" catenateWords="1" catenateNumbers="1" catenateAll="0"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
         <filter class="solr.EnglishMinimalStemFilterFactory"/>
         <!-- this filter can remove any duplicate tokens that appear at the same position - sometimes
-             possible with WordDelimiterFilter in conjuncton with stemming. -->
+             possible with WordDelimiterGraphFilterFactory in conjuncton with stemming. -->
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
     </fieldType>
@@ -391,7 +384,7 @@
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt"/>
         <filter class="solr.LowerCaseFilterFactory"/>
       </analyzer>
@@ -597,13 +590,7 @@
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
 
     <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
-
-   <!--
-    A Geohash is a compact representation of a latitude longitude pair in a single field.
-    See http://wiki.apache.org/solr/SpatialSearch
-   -->
-    <fieldtype name="geohash" class="solr.GeoHashField"/>
+    <fieldType name="location" class="solr.LatLonPointSpatialField"/>
  </types>
 
 
@@ -655,8 +642,8 @@
    <field name="title_sort" type="alphaNumSort" indexed="true" stored="false" />
    <!-- pub_date sort uses new trie-based int fields, which are recommended for any int and are displayable, sortable, and range-quer
    we use 'tint' for faster range-queries. -->
-   <field name="pub_date_start_sort" type="tint" indexed="true" stored="true" multiValued="false"/>
-   <field name="pub_date_end_sort" type="tint" indexed="true" stored="true" multiValued="false"/>
+   <field name="pub_date_start_sort" type="tint" indexed="true" stored="true" multiValued="false" docValues="true"/>
+   <field name="pub_date_end_sort" type="tint" indexed="true" stored="true" multiValued="false" docValues="true"/>
 
    <!-- format is used for facet, display, and choosing which partial to use for the show view, so it must be stored and indexed -->
    <field name="format" type="string" indexed="true" stored="true" multiValued="true"/>

--- a/solr_configs/pulmap/conf/schema.xml
+++ b/solr_configs/pulmap/conf/schema.xml
@@ -17,7 +17,7 @@
     <dynamicField name="*_d"    type="double"  stored="true"  indexed="true"/>
     <dynamicField name="*_dt"   type="date"    stored="true"  indexed="true"/>
     <dynamicField name="*_f"    type="float"   stored="true"  indexed="true"/>
-    <dynamicField name="*_i"    type="int"     stored="true"  indexed="true"/>
+    <dynamicField name="*_i"    type="int"     stored="true"  indexed="true" docValues="true"/>
     <dynamicField name="*_im"   type="int"     stored="true"  indexed="true" multiValued="true" />
     <dynamicField name="*_l"    type="long"    stored="true"  indexed="true"/>
     <dynamicField name="*_s"    type="string"  stored="true"  indexed="true"/>
@@ -70,15 +70,15 @@
     <fieldType name="string"  class="solr.StrField"  sortMissingLast="true" />
     <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
 
-    <fieldType name="int"    class="solr.TrieIntField"     precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="float"  class="solr.TrieFloatField"   precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="long"   class="solr.TrieLongField"    precisionStep="8" positionIncrementGap="0"/>
-    <fieldType name="double" class="solr.TrieDoubleField"  precisionStep="8" positionIncrementGap="0"/>
+    <fieldType name="int"    class="solr.IntPointField"/>
+    <fieldType name="float"  class="solr.FloatPointField"/>
+    <fieldType name="long"   class="solr.LongPointField"/>
+    <fieldType name="double" class="solr.DoublePointField"/>
 
     <!-- The format for this date field is of the form 1995-12-31T23:59:59Z.
          The trailing "Z" designates UTC time and is mandatory.
          A Trie based date field for faster date range queries and date faceting. -->
-    <fieldType name="date" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
+    <fieldType name="date" class="solr.DatePointField"/>
 
     <!--Binary data type. The data should be sent/retrieved in as Base64 encoded Strings -->
     <fieldtype name="binary" class="solr.BinaryField"/>
@@ -99,7 +99,7 @@
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.StandardTokenizerFactory"/>
-        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords_en.txt"/>
         <filter class="solr.LowerCaseFilterFactory"/>
         <filter class="solr.EnglishPossessiveFilterFactory"/>
@@ -140,7 +140,7 @@
     </fieldType>
 
     <!-- Spatial field types -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_d"/>
+    <fieldType name="location" class="solr.LatLonPointSpatialField"/>
 
     <fieldType name="location_rpt" class="solr.SpatialRecursivePrefixTreeFieldType"
                geo="true" distErrPct="0.025" maxDistErr="0.001" distanceUnits="kilometers"/>


### PR DESCRIPTION
Updating Solr configurations for compatibility with 7.1:
* updating all `Trie` fields to use new `Point` equivalents
* `LatLonType` is now `LatLonPointSpatialField`
* `GeoHashField` is removed
* configuring `commitReserveDuration` directly on replication
* `WordDelimiterFilterFactory` is now `WordDelimiterGraphFilterFactory`
* `StandardRequestHandler` is now `SearchHandler`
* `SynonymFilterFactory` is now `SynonymGraphFilterFactory` with a index-time `FlattenGraphFilterFactory`

Corresponding PRs to update apps with these config changes:
* Pomegranate: https://github.com/pulibrary/pomegranate/pull/402
* Figgy: https://github.com/pulibrary/figgy/pull/1507
* LAE: https://github.com/pulibrary/lae-blacklight/pull/237
* Pulmap: https://github.com/pulibrary/pulmap/pull/567

Closes #75 