### PR TITLE
remove unused cjk copy fields

### DIFF
--- a/solr_configs/orangelight/conf/schema.xml
+++ b/solr_configs/orangelight/conf/schema.xml
@@ -790,13 +790,6 @@
    <copyField source="more_in_this_series_t" dest="more_in_this_series_la"/>
 
    <!-- advanced search fields cjk config -->
-   <copyField source="series_title_index" dest="cjk_series_title"/>
-   <copyField source="series_ae_index" dest="cjk_series_title"/>
-   <copyField source="series_statement_index" dest="cjk_series_title"/>
-   <copyField source="linked_series_title_index" dest="cjk_series_title"/>
-   <copyField source="linked_series_index" dest="cjk_series_title"/>
-   <copyField source="original_version_series_index" dest="cjk_series_title"/>
-   <copyField source="notes_index" dest="cjk_notes"/>
    <copyField source="pub_created_vern_display" dest="cjk_publisher"/>
 
    <!-- Above, multiple source fields are copied to the [text] field.

--- a/spec/orangelight/cjk_mapping_spec.rb
+++ b/spec/orangelight/cjk_mapping_spec.rb
@@ -121,12 +121,12 @@ describe 'CJK character equivalence' do
       expect(solr_resp_doc_ids_only({ 'q' => '{!qf=$publisher_qf pf=$publisher_pf}三晉出版社' })).to include('1')
     end
     it '巴蜀書社 => 巴蜀书社  notes' do
-      solr.add({ id: 1, notes_index: '巴蜀書社' })
+      solr.add({ id: 1, cjk_notes: '巴蜀書社' })
       solr.commit
       expect(solr_resp_doc_ids_only({ 'q' => '{!qf=$notes_qf pf=$notes_pf}巴蜀书社 ' })).to include('1')
     end
     it '鳳凰出版社 => 凤凰出版社  series title' do
-      solr.add({ id: 1, original_version_series_index: '鳳凰出版社' })
+      solr.add({ id: 1, cjk_series_title: '鳳凰出版社' })
       solr.commit
       expect(solr_resp_doc_ids_only({ 'q' => '{!qf=$series_title_qf pf=$series_title_pf}凤凰出版社 ' })).to include('1')
     end


### PR DESCRIPTION
Removes copy fields. With https://github.com/pulibrary/marc_liberation/pull/441, the cjk_series_title and cjk_notes fields will be processed via Traject.