### PR TITLE
Starting architecture decision records

### DIFF
--- a/architecture-decisions/0001-document-architecture-decisions.md
+++ b/architecture-decisions/0001-document-architecture-decisions.md
@@ -1,0 +1,20 @@
+# 1. Record architecture decisions
+
+Date: 2018-11-14
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard in this article: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+
+## Consequences
+
+* See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's _adr-tools_ at https://github.com/npryce/adr-tools.
+* Pull requests that change configuration settings, either in this repository, or in https://github.com/pulibrary/princeton_ansible, should be accompanied by an ADR.


### PR DESCRIPTION
Cribbed from https://github.com/MITLibraries/mario/tree/master/docs/architecture-decisions