### PR TITLE
Implements Configset and Collection management Capistrano tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,28 @@ Note that `solr.xml` is used for development and testing on this repository, but
 
 This repository updates, but does not create, collections. To add a new collection, create its config here and deploy to get the config up to the server. Then use the UI to create the collection (TODO: how to make the config set available to the UI?). Finally, you can add the collection to the deploy scripts so that it will be updated in future deployments.
 
+## Managing Configsets
+
+*After deploying* one may list, upload, update, and delete Configsets using the following Capistrano tasks:
+```
+SOLR_URL=http://localhost:8983/solr bundle exec cap development configsets:list
+SOLR_URL=http://localhost:8983/solr bundle exec cap development configsets:upload[solr_configs/dpul/conf,dpul-config]
+SOLR_URL=http://localhost:8983/solr bundle exec cap development configsets:update[solr_configs/dpul_new/conf,dpul-config]
+SOLR_URL=http://localhost:8983/solr bundle exec cap development configsets:delete[dpul-config]
+```
+
+Please note that, when uploading a directory for a new Configset from this repository, that the `/conf` subdirectory should be used (e. g. `solr_configs/dpul/conf`)
+
+## Managing Collections
+
+Using Capistrano, one may create, reload, delete, and list Collections using the following tasks:
+```
+SOLR_URL=http://localhost:8983/solr bundle exec cap development collections:list
+SOLR_URL=http://localhost:8983/solr bundle exec cap development collections:create[dpul,dpul-config]
+SOLR_URL=http://localhost:8983/solr bundle exec cap development collections:reload[dpul]
+SOLR_URL=http://localhost:8983/solr bundle exec cap development collections:delete[dpul]
+```
+
 ## Specs
 
 Solr must be running in order for rspec-solr specs to run.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -36,6 +36,10 @@ set :filter, :roles => %w{main}
 # Default value for keep_releases is 5
 # set :keep_releases, 5
 
+def solr_url
+  ENV['SOLR_URL'] ||= 'http://localhost:8983/solr'
+end
+
 namespace :deploy do
   after :published, :restart do
     on roles(:main), wait: 5 do
@@ -68,7 +72,7 @@ end
 namespace :alias do
   task :list do
     on roles(:main) do
-      execute "curl 'http://localhost:8983/solr/admin/collections?action=LISTALIASES'"
+      execute "curl '#{solr_url}/admin/collections?action=LISTALIASES'"
     end
   end
 
@@ -80,13 +84,13 @@ namespace :alias do
     if production && rebuild
       on roles(:main) do
         # Delete the rebuild alias
-        execute "curl 'http://localhost:8983/solr/admin/collections?action=DELETEALIAS&name=catalog-rebuild'"
+        execute "curl '#{solr_url}/admin/collections?action=DELETEALIAS&name=catalog-rebuild'"
 
         # Move the catalog-production alias
-        execute "curl 'http://localhost:8983/solr/admin/collections?action=CREATEALIAS&name=catalog-production&collections=#{production}'"
+        execute "curl '#{solr_url}/admin/collections?action=CREATEALIAS&name=catalog-production&collections=#{production}'"
 
         # Add the rebuild alias to its new location
-        execute "curl 'http://localhost:8983/solr/admin/collections?action=CREATEALIAS&name=catalog-rebuild&collections=#{rebuild}'"
+        execute "curl '#{solr_url}/admin/collections?action=CREATEALIAS&name=catalog-rebuild&collections=#{rebuild}'"
       end
     else
       puts "Please set the PRODUCTION and REBUILD environment variables. For example:"
@@ -95,10 +99,96 @@ namespace :alias do
   end
 end
 
-def update_configset(config_dir:, config_set:)
-  execute "cd /opt/solr/bin && ./solr zk -upconfig -d #{File.join(release_path, "solr_configs", config_dir)} -n #{config_set}"
+namespace :configsets do
+  def list_configsets
+    execute "curl #{solr_url}/admin/configs?action=LIST&omitHeader=true"
+  end
+
+  def upload_configset(config_dir:, config_set:)
+    execute "(cd #{File.join(release_path, config_dir)} && zip -r - *) | curl -X POST --header 'Content-Type:application/octet-stream' --data-binary @- '#{solr_url}/admin/configs?action=UPLOAD&name=#{config_set}'"
+  end
+
+  def update_configset(config_dir:, config_set:)
+    execute "cd /opt/solr/bin && ./solr zk -upconfig -d #{File.join(release_path, "solr_configs", config_dir)} -n #{config_set}"
+  end
+
+  def delete_configset(config_set)
+    execute "curl #{solr_url}/admin/configs?action=DELETE&name=#{config_set}&omitHeader=true"
+  end
+
+  desc 'List all Configsets'
+  task :list do |task_name, args|
+    on roles(:main) do
+      list_configsets
+    end
+  end
+
+  desc 'Update a Configset'
+  task :update, :config_dir, :config_set do |task_name, args|
+    on roles(:main) do
+      update_configset(config_dir: args[:config_dir], config_set: args[:config_set])
+    end
+  end
+
+  desc 'Upload a Configset using a Solr config. directory'
+  task :upload, :config_dir, :config_set do |task_name, args|
+    on roles(:main) do
+      upload_configset(config_dir: args[:config_dir], config_set: args[:config_set])
+    end
+  end
+
+  desc 'Delete a Configset'
+  task :delete, :config_set do |task_name, args|
+    on roles(:main) do
+      delete_configset(args[:config_set])
+    end
+  end
 end
 
-def reload_collection(collection)
-  execute "curl 'http://localhost:8983/solr/admin/collections?action=RELOAD&name=#{collection}'"
+namespace :collections do
+  def list_collections
+    execute "curl '#{solr_url}/admin/collections?action=LIST'"
+  end
+
+  def create_collection(collection, config_name, num_shards = 1, replication_factor = 1)
+    execute "curl '#{solr_url}/admin/collections?action=CREATE&name=#{collection}&collection.configName=#{config_name}&numShards=#{num_shards}&replicationFactor=#{replication_factor}'"
+  end
+
+  def reload_collection(collection)
+    execute "curl '#{solr_url}/admin/collections?action=RELOAD&name=#{collection}'"
+  end
+
+  def delete_collection(collection)
+    execute "curl '#{solr_url}/admin/collections?action=DELETE&name=#{collection}'"
+  end
+
+  desc 'List Collections'
+  task :list do
+    on roles(:main) do
+      list_collections
+    end
+  end
+
+  desc 'Reload a Collection'
+  task :reload, :collection do |task_name, args|
+    on roles(:main) do
+      reload_collection(args[:collection])
+    end
+  end
+
+  desc 'Create a Collection'
+  task :create, :collection, :config_name, :num_shards, :replication_factor do |task_name, args|
+    on roles(:main) do
+      num_shards = args[:num_shards] || 1
+      replication_factor = args[:replication_factor] || 1
+      create_collection(args[:collection], args[:config_name], num_shards, replication_factor)
+    end
+  end
+
+  desc 'Delete a Collection'
+  task :delete, :collection do |task_name, args|
+    on roles(:main) do
+      delete_collection(args[:delete])
+    end
+  end
 end

--- a/config/deploy/development.rb
+++ b/config/deploy/development.rb
@@ -1,0 +1,65 @@
+# server-based syntax
+# ======================
+# Defines a single server with a list of roles and multiple properties.
+# You can define all roles on a single server, or split them:
+
+server 'localhost', user: 'deploy', roles: %{main}
+
+# server 'example.com', user: 'deploy', roles: %w{app web}, other_property: :other_value
+# server 'db.example.com', user: 'deploy', roles: %w{db}
+
+set :branch, ENV['BRANCH'] || 'master'
+
+# role-based syntax
+# ==================
+
+# Defines a role with one or multiple servers. The primary server in each
+# group is considered to be the first unless any  hosts have the primary
+# property set. Specify the username and a domain or IP for the server.
+# Don't use `:all`, it's a meta role.
+
+# role :app, %w{deploy@example.com}, my_property: :my_value
+# role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
+# role :db,  %w{deploy@example.com}
+
+
+
+# Configuration
+# =============
+# You can set any configuration variable like in config/deploy.rb
+# These variables are then only loaded and set in this stage.
+# For available Capistrano configuration variables see the documentation page.
+# http://capistranorb.com/documentation/getting-started/configuration/
+# Feel free to add new variables to customise your setup.
+
+
+
+# Custom SSH Options
+# ==================
+# You may pass any option but keep in mind that net/ssh understands a
+# limited set of options, consult the Net::SSH documentation.
+# http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start
+#
+# Global options
+# --------------
+#  set :ssh_options, {
+#    keys: %w(/home/rlisowski/.ssh/id_rsa),
+#    forward_agent: false,
+#    auth_methods: %w(password)
+#  }
+set :ssh_options, {
+  port: 2222
+}
+#
+# The server-based syntax can be used to override options:
+# ------------------------------------
+# server 'example.com',
+#   user: 'user_name',
+#   roles: %w{web app},
+#   ssh_options: {
+#     user: 'user_name', # overrides user setting above
+#     keys: %w(/home/user_name/.ssh/id_rsa),
+#     forward_agent: false,
+#     auth_methods: %w(publickey password)
+#     # password: 'please use keys'
+#   }


### PR DESCRIPTION
These tasks enable one to readily upload, update, and delete Configsets along with creating and deleting Collections once `pul_solr` has been deployed to a server environment.  This also adds a development deployment environment for testing this using a Vagrant box.