### PR TITLE
Only do GraphFilter at index time.

### DIFF
--- a/solr_configs/catalog-production/conf/schema.xml
+++ b/solr_configs/catalog-production/conf/schema.xml
@@ -177,10 +177,16 @@
          http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters
      -->
      <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
-       <analyzer>
+       <analyzer type="index">
          <tokenizer class="solr.StandardTokenizerFactory"/>
          <filter class="solr.ICUFoldingFilterFactory" />
          <filter class="solr.WordDelimiterGraphFilterFactory" catenateAll="1" preserveOriginal="1"/>
+         <filter class="solr.FlattenGraphFilterFactory"/>
+         <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
+       </analyzer>
+       <analyzer type="query">
+         <tokenizer class="solr.StandardTokenizerFactory"/>
+         <filter class="solr.ICUFoldingFilterFactory" />
          <filter class="solr.FlattenGraphFilterFactory"/>
          <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
        </analyzer>

--- a/solr_configs/catalog-staging/conf/schema.xml
+++ b/solr_configs/catalog-staging/conf/schema.xml
@@ -177,10 +177,16 @@
          http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters
      -->
      <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
-       <analyzer>
+       <analyzer type="index">
          <tokenizer class="solr.StandardTokenizerFactory"/>
          <filter class="solr.ICUFoldingFilterFactory" />
          <filter class="solr.WordDelimiterGraphFilterFactory" catenateAll="1" preserveOriginal="1"/>
+         <filter class="solr.FlattenGraphFilterFactory"/>
+         <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
+       </analyzer>
+       <analyzer type="query">
+         <tokenizer class="solr.StandardTokenizerFactory"/>
+         <filter class="solr.ICUFoldingFilterFactory" />
          <filter class="solr.FlattenGraphFilterFactory"/>
          <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
        </analyzer>


### PR DESCRIPTION
This stops Solr from crashing because of queries with long URLs.