### PR TITLE
includes genre terms in subject keyword search

### DIFF
--- a/solr_configs/catalog-production-alt/conf/schema.xml
+++ b/solr_configs/catalog-production-alt/conf/schema.xml
@@ -746,7 +746,9 @@
 
    <!-- unstemmed fields -->
    <copyField source="title_display" dest="title_unstem_search"/>
-   <copyField source="subject_display" dest="subject_unstem_search"/>
+   <copyField source="lcgft_s" dest="genre_unstem_search"/>
+   <copyField source="aat_s" dest="genre_unstem_search"/>
+   <copyField source="rbgenr_s" dest="genre_unstem_search"/>
    <copyField source="subject_topic_facet" dest="subject_topic_unstem_search"/>
 
 

--- a/solr_configs/catalog-production-alt/conf/solrconfig.xml
+++ b/solr_configs/catalog-production-alt/conf/solrconfig.xml
@@ -269,7 +269,9 @@
         author_unstem_search^40
         subject_topic_unstem_search^18
         subject_unstem_search^15
+        siku_subject_unstem_search^15
         subject_topic_index^12
+        genre_unstem_search^10
         subject_t^10
         subject_addl_unstem_search^8
         subject_addl_t^4
@@ -290,7 +292,9 @@
         author_unstem_search^400
         subject_topic_unstem_search^180
         subject_unstem_search^150
+        siku_subject_unstem_search^150
         subject_topic_index^120
+        genre_unstem_search^100
         subject_t^100
         subject_addl_unstem_search^80
         subject_addl_t^40
@@ -407,11 +411,15 @@
       <str name="subject_qf">
         subject_topic_unstem_search^25
         subject_unstem_search^20
+        genre_unstem_search^15
+        siku_subject_unstem_search
         cjk_subject
       </str>
       <str name="subject_pf">
         subject_topic_unstem_search^250
         subject_unstem_search^200
+        genre_unstem_search^150
+        siku_subject_unstem_search^10
         cjk_subject^10
       </str>
 

--- a/solr_configs/catalog-staging/conf/schema.xml
+++ b/solr_configs/catalog-staging/conf/schema.xml
@@ -718,7 +718,9 @@
 
    <!-- unstemmed fields -->
    <copyField source="title_display" dest="title_unstem_search"/>
-   <copyField source="subject_display" dest="subject_unstem_search"/>
+   <copyField source="lcgft_s" dest="genre_unstem_search"/>
+   <copyField source="aat_s" dest="genre_unstem_search"/>
+   <copyField source="rbgenr_s" dest="genre_unstem_search"/>
    <copyField source="subject_topic_facet" dest="subject_topic_unstem_search"/>
 
 

--- a/solr_configs/catalog-staging/conf/solrconfig.xml
+++ b/solr_configs/catalog-staging/conf/solrconfig.xml
@@ -269,7 +269,9 @@
         author_unstem_search^40
         subject_topic_unstem_search^18
         subject_unstem_search^15
+        siku_subject_unstem_search^15
         subject_topic_index^12
+        genre_unstem_search^10
         subject_t^10
         subject_addl_unstem_search^8
         subject_addl_t^4
@@ -290,7 +292,9 @@
         author_unstem_search^400
         subject_topic_unstem_search^180
         subject_unstem_search^150
+        siku_subject_unstem_search^150
         subject_topic_index^120
+        genre_unstem_search^100
         subject_t^100
         subject_addl_unstem_search^80
         subject_addl_t^40
@@ -407,11 +411,15 @@
       <str name="subject_qf">
         subject_topic_unstem_search^25
         subject_unstem_search^20
+        genre_unstem_search^15
+        siku_subject_unstem_search
         cjk_subject
       </str>
       <str name="subject_pf">
         subject_topic_unstem_search^250
         subject_unstem_search^200
+        genre_unstem_search^150
+        siku_subject_unstem_search^10
         cjk_subject^10
       </str>
 
@@ -517,5 +525,4 @@
       <str name="q">{!raw f=id v=$id}</str> <!-- use id=666 instead of q=id:666 -->
     </lst>
   </requestHandler>
-
 </config>

--- a/spec/orangelight/subject_search_spec.rb
+++ b/spec/orangelight/subject_search_spec.rb
@@ -37,7 +37,7 @@ describe 'subject keyword search' do
   end
   describe 'stemming disabled' do
     before(:all) do
-      solr.add({ id: 1, subject_display: 'Biographical films—United States' })
+      solr.add({ id: 1, subject_unstem_search: 'Biographical films—United States' })
       solr.commit
     end
     it 'matches heading terms exactly' do


### PR DESCRIPTION
Makes genre terms searchable in unstem_search fields.
Supports separated siku and lc subject fields.
Updated version of https://github.com/pulibrary/pul_solr/pull/181