### PR TITLE
Uses the correct syntax in the fq parameter 

### DIFF
--- a/solr_configs/catalog-staging/conf/solrconfig.xml
+++ b/solr_configs/catalog-staging/conf/solrconfig.xml
@@ -153,13 +153,13 @@
         <lst><str name="fq">location:Stokes Library</str></lst>
         <lst><str name="fq">location:Video Library</str></lst>
 
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-7DAYS NOW/DAY+1DAY]</str></lst>
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-14DAYS NOW/DAY+1DAY]</str></lst>
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-21DAYS NOW/DAY+1DAY]</str></lst>
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-1MONTH NOW/DAY+1DAY]</str></lst>
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-2MONTHS NOW/DAY+1DAY]</str></lst>
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-3MONTHS NOW/DAY+1DAY]</str></lst>
-        <lst><str name="fq">cataloged_tdt:[NOW/DAY-6MONTHS NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-7DAYS TO NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-14DAYS TO NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-21DAYS TO NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-1MONTH TO NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-2MONTHS TO NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-3MONTHS TO NOW/DAY+1DAY]</str></lst>
+        <lst><str name="fq">cataloged_tdt:[NOW/DAY-6MONTHS TO NOW/DAY+1DAY]</str></lst>
 
         <lst><str name="fq">language_facet:English</str></lst>
         <lst><str name="fq">language_facet:German</str></lst>


### PR DESCRIPTION
It uses the correct syntax to indicate a date range in the `<lst><str name="fq">cataloged_tdt...` settings.

The new syntax removes the Solr warning in the log referenced in https://github.com/pulibrary/marc_liberation/issues/1019.

This change needs to be merged before we can test https://github.com/pulibrary/marc_liberation/pull/1056

