### PR TITLE
[Pulfalight] Improve relevancy for title searches via keywords

### DIFF
--- a/solr_configs/pulfalight-production/conf/solrconfig.xml
+++ b/solr_configs/pulfalight-production/conf/solrconfig.xml
@@ -90,7 +90,7 @@
          containers_tesim
          physloc_tesim
          collection_title_tesim
-         title_tesim
+         title_teim
          name_tsim
          place_tsim
          unitid_identifier_match
@@ -100,9 +100,9 @@
          text
        </str>
        <str name="pf">
-         title_tesim^10
-         name_tsim^10
-         place_tsim^10
+         title_teim^4
+         name_tsim^2
+         place_tsim^2
          subject_tsim^2
        </str>
        <str name="pf2">
@@ -130,13 +130,12 @@
          subject_tsim
        </str>
        <str name="qf_title">
-         title_tesim
+         title_teim
        </str>
        <str name="pf_title">
-         title_tesim
+         title_teim
        </str>
 
-       <int name="ps">3</int>
        <float name="tie">0.01</float>
 
        <str name="fl">

--- a/solr_configs/pulfalight-staging/conf/solrconfig.xml
+++ b/solr_configs/pulfalight-staging/conf/solrconfig.xml
@@ -90,7 +90,7 @@
          containers_tesim
          physloc_tesim
          collection_title_tesim
-         title_tesim
+         title_teim
          name_tsim
          place_tsim
          unitid_identifier_match
@@ -100,7 +100,7 @@
          text
        </str>
        <str name="pf">
-         title_tesim^10
+         title_teim^10
          name_tsim^5
          place_tsim^5
          subject_tsim^2
@@ -130,10 +130,10 @@
          subject_tsim
        </str>
        <str name="qf_title">
-         title_tesim
+         title_teim
        </str>
        <str name="pf_title">
-         title_tesim
+         title_teim
        </str>
 
        <float name="tie">0.01</float>

--- a/solr_configs/pulfalight-staging/conf/solrconfig.xml
+++ b/solr_configs/pulfalight-staging/conf/solrconfig.xml
@@ -101,8 +101,8 @@
        </str>
        <str name="pf">
          title_tesim^10
-         name_tsim^10
-         place_tsim^10
+         name_tsim^5
+         place_tsim^5
          subject_tsim^2
        </str>
        <str name="pf2">
@@ -136,7 +136,6 @@
          title_tesim
        </str>
 
-       <int name="ps">3</int>
        <float name="tie">0.01</float>
 
        <str name="fl">

--- a/solr_configs/pulfalight-staging/conf/solrconfig.xml
+++ b/solr_configs/pulfalight-staging/conf/solrconfig.xml
@@ -100,9 +100,9 @@
          text
        </str>
        <str name="pf">
-         title_teim^10
-         name_tsim^5
-         place_tsim^5
+         title_teim^4
+         name_tsim^2
+         place_tsim^2
          subject_tsim^2
        </str>
        <str name="pf2">


### PR DESCRIPTION
Removes phrase slop (which will weight closer phrases higher), boosts the right title field, and lowers the title boost so that the collection boost in Pulfalight will take priority.