### PR TITLE
Adds gems needed to run bundle exec cap solr-server-name solr:console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,9 @@ gem 'rsolr'
 gem 'rspec', '~> 3.8'
 gem 'solr_wrapper'
 gem 'whenever'
+gem 'rbnacl', '>= 3.2', '< 5.0'
+gem 'rbnacl-libsodium'
+gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
 
 group :development do
   gem 'capistrano', '~> 3.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.3.0)
       sshkit (>= 1.6.1, != 1.7.0)
+    bcrypt_pbkdf (1.1.0)
     builder (3.2.3)
     byebug (9.1.0)
     capistrano (3.10.1)
@@ -28,6 +29,7 @@ GEM
     diff-lcs (1.3)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
+    ffi (1.15.3)
     hashdiff (1.0.1)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
@@ -44,6 +46,10 @@ GEM
       pry (~> 0.10)
     public_suffix (4.0.6)
     rake (12.3.3)
+    rbnacl (4.0.2)
+      ffi
+    rbnacl-libsodium (1.0.16)
+      rbnacl (>= 3.0.1)
     retriable (3.1.2)
     rsolr (2.1.0)
       builder (>= 2.1.2)
@@ -87,11 +93,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt_pbkdf (>= 1.0, < 2.0)
   capistrano (~> 3.9)
   capistrano-bundler
   faraday
   pry-byebug
   rake
+  rbnacl (>= 3.2, < 5.0)
+  rbnacl-libsodium
   rsolr
   rspec (~> 3.8)
   rspec-solr (~> 3.0)
@@ -101,4 +110,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.1.4
+   2.2.16


### PR DESCRIPTION
Updated Gemfile handles the error that is triggered when running the command `bundle exec cap solr8-production solr:console` on the Terminal. 

The error was:
```
#<Thread:0x00007ff3a79f6e18@/Users/correah/.gem/ruby/2.6.6/gems/sshkit-1.15.1/lib/sshkit/runners/parallel.rb:10 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	18: from /Users/correah/.gem/ruby/2.6.6/gems/sshkit-1.15.1/lib/sshkit/runners/parallel.rb:12:in `block (2 levels) in execute'
	17: from /Users/correah/.gem/ruby/2.6.6/gems/sshkit-1.15.1/lib/sshkit/backends/abstract.rb:29:in `run'
	16: from /Users/correah/.gem/ruby/2.6.6/gems/sshkit-1.15.1/lib/sshkit/backends/abstract.rb:29:in `instance_exec'
	15: from config/deploy.rb:197:in `block (3 levels) in <top (required)>'
	14: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh.rb:241:in `start'
	13: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/authentication/session.rb:66:in `authenticate'
	12: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/authentication/session.rb:66:in `each'
	11: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/authentication/session.rb:80:in `block in authenticate'
	10: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/authentication/methods/publickey.rb:19:in `authenticate'
	 9: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/authentication/key_manager.rb:119:in `each_identity'
	 8: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/authentication/key_manager.rb:119:in `each'
	 7: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/authentication/key_manager.rb:122:in `block in each_identity'
	 6: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/authentication/methods/publickey.rb:20:in `block in authenticate'
	 5: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/authentication/methods/publickey.rb:62:in `authenticate_with'
	 4: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/authentication/key_manager.rb:142:in `sign'
	 3: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/key_factory.rb:43:in `load_private_key'
	 2: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/key_factory.rb:52:in `load_data_private_key'
	 1: from /Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/key_factory.rb:112:in `classify_key'
/Users/correah/.gem/ruby/2.6.6/gems/net-ssh-4.2.0/lib/net/ssh/authentication/ed25519_loader.rb:19:in `raiseUnlessLoaded': OpenSSH keys only supported if ED25519 is available (NotImplementedError)
net-ssh requires the following gems for ed25519 support:
 * rbnacl (>= 3.2, < 5.0)
 * rbnacl-libsodium, if your system doesn't have libsodium installed.
 * bcrypt_pbkdf (>= 1.0, < 2.0)
See https://github.com/net-ssh/net-ssh/issues/478 for more information
Gem::LoadError : "rbnacl is not part of the bundle. Add it to your Gemfile."
(Backtrace restricted to imported tasks)
cap aborted!
NotImplementedError: OpenSSH keys only supported if ED25519 is available
net-ssh requires the following gems for ed25519 support:
 * rbnacl (>= 3.2, < 5.0)
 * rbnacl-libsodium, if your system doesn't have libsodium installed.
 * bcrypt_pbkdf (>= 1.0, < 2.0)
See https://github.com/net-ssh/net-ssh/issues/478 for more information
Gem::LoadError : "rbnacl is not part of the bundle. Add it to your Gemfile."
```

Notice that I had to force a very narrow version range on the gems, as suggested on the error message, otherwise Bundler picked up versions that were too new.

After a successfull `bundle install` with this gem file I had to execute the following commands to address a new error: "No digester supplied (SSHKit::Runner::ExecuteError)" ([more info](https://stackoverflow.com/questions/49857045/sshkitrunnerexecuteerror-exception-while-executing-as-deployxx-xxx-xx-xx)) before the `cap` command executed successfully. 

```
eval ssh-agent
ssh-add ~/.ssh/id_rsa 
```