### PR TITLE
Multi-arch docker build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ To update and rebuild the image:
 ```bash
 cd docker/
 docker login # login to docker hub
+docker buildx create --use # only necessary the first time you want to build an image
 docker buildx build --platform linux/arm64/v8,linux/amd64 -t pulibrary/ci-solr:{solr version}-{Dockerfile version} --push .
 ```
 For example, if you are building with solr 8.4 and Dockerfile 1.0.0:
@@ -204,6 +205,7 @@ For example, if you are building with solr 8.4 and Dockerfile 1.0.0:
 ```bash
 cd docker/
 docker login # login to docker hub
+docker buildx create --use
 docker buildx build --platform linux/arm64/v8,linux/amd64 -t pulibrary/ci-solr:8.4-v1.0.0 --push .
 ```
 
@@ -211,4 +213,5 @@ You can also push to your own Github Container Registry, if you are just testing
 
 1. [Login to the container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
 1. `cd docker`
-1. `docker buildx build --platform linux/arm64/v8,linux/amd64 -t ghcr.io/[username]/ci-solr:{solr version}-{Dockerfile version} --push .`
+2. `docker buildx create --use # only necessary the first time`
+3. `docker buildx build --platform linux/arm64/v8,linux/amd64 -t ghcr.io/[username]/ci-solr:{solr version}-{Dockerfile version} --push .`

--- a/README.md
+++ b/README.md
@@ -197,13 +197,12 @@ To update and rebuild the image:
 ```bash
 cd docker/
 docker login # login to docker hub
-docker build -t pulibrary/ci-solr:{solr version}-{Dockerfile version} .
-docker push pulibrary/ci-solr:{solr version}-{Dockerfile version}
+docker buildx build --platform linux/arm64/v8,linux/amd64 -t pulibrary/ci-solr:{solr version}-{Dockerfile version} --push .
 ```
+For example, if you are building with solr 8.4 and Dockerfile 1.0.0:
 
 ```bash
 cd docker/
 docker login # login to docker hub
-docker build -t pulibrary/ci-solr:8.4-v1.0.0 .
-docker push pulibrary/ci-solr:8.4-v1.0.0
+docker buildx build --platform linux/arm64/v8,linux/amd64 -t pulibrary/ci-solr:8.4-v1.0.0 --push .
 ```

--- a/README.md
+++ b/README.md
@@ -206,3 +206,9 @@ cd docker/
 docker login # login to docker hub
 docker buildx build --platform linux/arm64/v8,linux/amd64 -t pulibrary/ci-solr:8.4-v1.0.0 --push .
 ```
+
+You can also push to your own Github Container Registry, if you are just testing something out:
+
+1. [Login to the container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+1. `cd docker`
+1. `docker buildx build --platform linux/arm64/v8,linux/amd64 -t ghcr.io/[username]/ci-solr:{solr version}-{Dockerfile version} --push .`


### PR DESCRIPTION
`docker buildx build` is a good way to build this image so that it is compatible with arm64 (new Mac chips) and amd64 architectures.

Expected output when you build using this process:

- `docker inspect image IMAGE_TAG | grep -i architecture` should say amd64 on an Intel chip and arm64 on an M1 mac.
- `docker manifest inspect  IMAGE_TAG` should have entries for both amd64 and arm64.
