### PR TITLE
Add hash to orangelight config for dynamic sitemaps

### DIFF
--- a/solr_configs/catalog-production-v2/conf/schema.xml
+++ b/solr_configs/catalog-production-v2/conf/schema.xml
@@ -665,6 +665,7 @@
         Longer patterns will be matched first.  if equal size patterns
         both match, the first appearing in the schema will be used.  -->
    <dynamicField name="*_s"  type="string"  indexed="true"  stored="true" multiValued="true"/>
+   <dynamicField name="*_ssi" type="string" stored="true" indexed="true" multiValued="false"/>
    <dynamicField name="*_t"  type="text"    indexed="true"  stored="true" multiValued="true"/>
    <dynamicField name="*_txt" type="text_general"    indexed="true"  stored="true" multiValued="true"/>
    <dynamicField name="*_b"  type="boolean" indexed="true"  stored="true"/>

--- a/solr_configs/catalog-production-v2/conf/solrconfig.xml
+++ b/solr_configs/catalog-production-v2/conf/solrconfig.xml
@@ -46,6 +46,20 @@
     </autoSoftCommit>
   </updateHandler>
 
+  <updateProcessor class="solr.processor.SignatureUpdateProcessorFactory" name="add_hash_id">
+    <bool name="enabled">true</bool>
+    <str name="signatureField">hashed_id_ssi</str>
+    <bool name="overwriteDupes">false</bool>
+    <str name="fields">id</str>
+    <str name="signatureClass">solr.processor.Lookup3Signature</str>
+  </updateProcessor>
+
+  <updateRequestProcessorChain name="cloud" processor="add_hash_id" default="true">
+    <processor class="solr.LogUpdateProcessorFactory"/>
+    <processor class="solr.DistributedUpdateProcessorFactory"/>
+    <processor class="solr.RunUpdateProcessorFactory"/>
+  </updateRequestProcessorChain>
+
   <codecFactory class="solr.SchemaCodecFactory"/>
   <schemaFactory class="ClassicIndexSchemaFactory"/>
 

--- a/spec/orangelight/hash_id_spec.rb
+++ b/spec/orangelight/hash_id_spec.rb
@@ -1,5 +1,13 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
-require 'json'
+require 'rspec/expectations'
+
+RSpec::Matchers.define :contain_only_hexadecimal_characters do
+  match do |string|
+    !string[/\H/]
+  end
+end
 
 describe 'hash id field solrconfig update handler' do
   include_context 'solr_helpers'
@@ -13,10 +21,14 @@ describe 'hash id field solrconfig update handler' do
       solr.commit
     end
     it 'hashed id field is indexed' do
-      pending "Disabled until we implement dynamic site maps."
-      expect(solr_resp_doc_ids_only({ 'q': 'hashed_id_s:*'  })).to include('1')
+      expect(solr_resp_doc_ids_only({ 'q': 'hashed_id_ssi:*' })).to include('1')
     end
-
+    it 'creates hexadecimal hashes of the expected length' do
+      response = solr_response({ 'q' => 'id:1', 'fl' => 'hashed_id_ssi' })
+      hashed_id = response['response']['docs'].first['hashed_id_ssi']
+      expect(hashed_id.length).to eq(16)
+      expect(hashed_id).to contain_only_hexadecimal_characters
+    end
   end
   after(:all) do
     delete_all


### PR DESCRIPTION
This brings back the hashed id field added in https://github.com/pulibrary/pul_solr/pull/161, also taking inspiration from https://github.com/pulibrary/pul_solr/pull/323

Merging this is a prerequisite to https://github.com/pulibrary/orangelight/issues/3166