### PR TITLE
Change blockUnknown to false for CI

### DIFF
--- a/docker/security.json
+++ b/docker/security.json
@@ -1,6 +1,6 @@
 {
 "authentication":{
-   "blockUnknown": true,
+   "blockUnknown": false,
    "class":"solr.BasicAuthPlugin",
    "credentials":{"solr":"IV0EHq1OnNrj6gvRCwvFwTrZ1+z1oBbnQdiVC3otuq0= Ndd7LKvVBAaZIF0QAVi1ekCfAJXr1GGfLtRUXhgrF8c="},
    "realm":"My Solr users",


### PR DESCRIPTION
- Bibdata indexing in CI was failing with the existing image

Connected to https://github.com/pulibrary/bibdata/issues/2161 - replace solr_wrapper for CI

With blockUnknown set to "true" traject was getting authentication errors each time it was trying to index to Solr. (see, e.g., [this CI run](https://app.circleci.com/pipelines/github/pulibrary/bibdata/3138/workflows/23dbea9d-02c2-439b-9967-d57fb985405f/jobs/13638) - when I re-ran with SSH and put a byebug in, the traject errors were because Solr was returning a 401 authentication error)