### PR TITLE
Revert "Increase documentCache size for the Catalog"

### DIFF
--- a/solr_configs/catalog-production-v2/conf/solrconfig.xml
+++ b/solr_configs/catalog-production-v2/conf/solrconfig.xml
@@ -127,8 +127,8 @@
                       autowarmCount="32"/>
 
     <documentCache class="solr.LRUCache"
-                   size="32768"
-                   initialSize="32768"/>
+                   size="4096"
+                   initialSize="4096"/>
 
     <enableLazyFieldLoading>true</enableLazyFieldLoading>
 


### PR DESCRIPTION
This reverts commit 0a0e7ce39f0b626c5ec2c77c321fc3331a85c8c7.

It is unclear; however, this may be causing very slow garbage collection intermittently, and it is not clear that it is truly increasing performance (there seems to be a performance gain after every deploy, which can mask true performance gains); the DocumentCache hit ratio was still low at 0.22 even after this change.