### PR TITLE
Added author_display field explicitly

### DIFF
--- a/solr_configs/catalog-production-v2/conf/schema.xml
+++ b/solr_configs/catalog-production-v2/conf/schema.xml
@@ -505,6 +505,8 @@
    <field name="title_display" type="text" indexed="true" stored="true" multiValued="false"/>
    <field name="title_vern_display" type="text" indexed="true" stored="true" multiValued="false"/>
 
+   <!-- this field is required to be explicitly defined for search highlighing -->
+   <field name="author_display" type="text" indexed="true" stored="true" multiValued="true"/>
 
    <!-- these fields are also used for display, so they must be stored -->
    <field name="isbn_t" type="isbn" indexed="true" stored="true" multiValued="true"/>


### PR DESCRIPTION
Resolves pulibrary/orangelight#3830

The field was not adding emphasis because the highlighting results require the field to be explicitly defined in the schema.xml

In the future we will need to make sure any fields we add to highlighting isn't a dynamically defined field.