### PR TITLE
Use lib-solr-prod7 instead of lib-solr-prod4

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,4 +1,4 @@
-server 'lib-solr-prod4', user: 'deploy', roles: %{main}
+server 'lib-solr-prod7', user: 'deploy', roles: %{main}
 
 set :whenever_host, ->{ "solr8" }
 set :whenever_environment, ->{ "production" }


### PR DESCRIPTION
We removed lib-solr-prod4, now we should use 7.

The rake tasks seem to work fine.

Closes #398 