### PR TITLE
switches to new jammy VMs for prod zk cluster

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -4,7 +4,7 @@ set :whenever_host, ->{ "solr8" }
 set :whenever_environment, ->{ "production" }
 
 def zk_host
-  "lib-zk1:2181,lib-zk2:2181,lib-zk3:2181/solr8"
+  "lib-zk-prod1:2181,lib-zk-prod2:2181,lib-zk-prod3:2181/solr8"
 end
 
 # config directory => config set name


### PR DESCRIPTION
Related to https://github.com/pulibrary/princeton_ansible/issues/4858 and https://github.com/pulibrary/princeton_ansible/issues/4969.

We have upgraded the production zookeeper cluster to run on Ubuntu 22 (Jammy Jellyfish). This PR updates the production deployment to use the new infrastructure.
