### PR TITLE
[heap dump docs] Use nsenter to bypass systemd security protections

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,28 +145,32 @@ If you have no idea what is happening on solr you may want to try dumping the
 heap. This is difficult when GC is freezing everything. Keep trying and
 eventually you may be lucky!
 
-Run as deploy user:
-`jmap -dump:format=b,file=/home/deploy/solr.hprof [pid_of_solr_process]`
+1. Run as pulsys user:
 
-Then you'll want to look at it. Download the file to your machine
-`scp deploy@lib-solrN:/home/deploy/solr.hprof .`
+        sudo nsenter -t [pid_of_solr_process] -m # Enter the namespace of the Solr PID, so that systemd security settings don't block the dump
+        sudo su - deploy # jmap must be run as the same user as solr
+        jmap -dump:format=b,file=/home/deploy/solr.hprof [pid_of_solr_process]
 
-Download and install the [eclipse memory analyzer](https://www.eclipse.org/mat/downloads.php) application.
+1. Then you'll want to look at it. Download the file to your machine
 
-You need to assign enough heap to the app to hold the entire heap that you
+        scp deploy@lib-solrN:/home/deploy/solr.hprof .
+
+1. Download and install the [eclipse memory analyzer](https://www.eclipse.org/mat/downloads.php) application.
+
+1. You need to assign enough heap to the app to hold the entire heap that you
 dumped on the server. When you unzip it you get a `mat` directory. Right click
 and select "Show Package Contents", then expand contents > eclipse > right click
 on "MemoryAnalyzer.ini" to edit. Change "-Xmx" to be a number bigger than the
 file you have.
 
-You're supposed to be able to double-click the 'mat' file but that doesn't work.
+1. You're supposed to be able to double-click the 'mat' file but that doesn't work.
 you have to "Show Package Contents" > Contents > MacOS > run 'MemoryAnalyzer'
 
-Congratulations! You opened the application. Now open the heap file and wait a
+1. Congratulations! You opened the application. Now open the heap file and wait a
 long time while it parses the file and the progress bar jumps around. It took
 about an hour for a 20g file for us.
 
-You want to look at the dominator tree to see how much heap is used by each
+1. You want to look at the dominator tree to see how much heap is used by each
 object. Right-click the biggest one's thread (higher in the tree) > Java Basics > Thread Overview and Stacks. Expand the thread click the "total" button at the bottom so all of them will open up. Expand the first column (Object stack frame). Expand 'org.eclipse.jetty.servlet.ServletHandler.doHandle'. Click the first (local) frame. Look on the left, double-click the + to expand more properties, the thing that broke it was `_originalURI`. right-click > copy value.
 
 ## Solr Docker


### PR DESCRIPTION
Since these instructions were first written, we have [configured solr as a systemd service with `PrivateTmp=true`](https://github.com/pulibrary/princeton_ansible/pull/4874).  This is a good security protection to have, but it unfortunately also blocks the heap dump.

The nsenter command allows us to bypass this protection temporarily by entering the "namespace" of the solr process.

Also, format the steps as an ordered list.