### PR TITLE
[catalog] Include call_number_display field in the default fl

### DIFF
--- a/solr_configs/catalog-production-v2/conf/solrconfig.xml
+++ b/solr_configs/catalog-production-v2/conf/solrconfig.xml
@@ -334,7 +334,8 @@
         electronic_access_1display,
         electronic_portfolio_s,
         cataloged_tdt,
-        contained_in_s
+        contained_in_s,
+        call_number_display
       </str>
 
       <str name="facet">true</str>

--- a/spec/orangelight/default_fields_spec.rb
+++ b/spec/orangelight/default_fields_spec.rb
@@ -1,0 +1,21 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe 'default fields' do
+  include_context 'solr_helpers'
+
+  before do
+    delete_all
+    add_doc('212556')
+    solr.commit
+  end
+  it 'contains call_number_display field' do
+    docs = solr.get('select', :params => {q: 'id:212556'})['response']['docs']
+    expect(docs.first['call_number_display']).to contain_exactly 'BH301.A94 B8313 1984'
+  end
+
+  after do
+    delete_all
+    solr.commit
+  end
+end


### PR DESCRIPTION
Orangelight has a feature where users can text themselves the call number of an item. While working on pulibrary/orangelight#4479, we found that this feature wasn't working, because we never actually told solr that we want to get the call_number_display field.

This adds call_number_display to the fl list, so it is retrieved by default.