### PR TITLE
adds CDH Solr9 collections to backup rake task

### DIFF
--- a/config/deploy/solr9_production.rb
+++ b/config/deploy/solr9_production.rb
@@ -10,6 +10,8 @@ end
 # config directory => config set name
 def config_map
   {
+    "cdh_ppa" => "cdh_ppa",
+    "geniza" => "geniza"
   }
 end
 

--- a/config/deploy/solr9_staging.rb
+++ b/config/deploy/solr9_staging.rb
@@ -13,8 +13,8 @@ end
 # config directory => config set name
 def config_map
   {
-  #  "cdh_ppa" => "cdh_ppa",
-  #  "geniza" => "geniza"
+    "cdh_ppa" => "cdh_ppa",
+    "geniza" => "geniza"
   }
 end
 


### PR DESCRIPTION
The CDH collections are live on Solr9 in both staging and production. This PR adds them to the `config_map` so those collections will get backed up by the rake task. 