### PR TITLE
adds instructions for adding a new core/collection for backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ inventory](https://docs.google.com/spreadsheets/d/118O7JeVEPaoVsCIxoWLdDTctcTCe4
 
 ## Adding a new core
 
-This repository updates, but does not create, collections. To add a new collection, create its config here and deploy to get the config up to the server. Then use the UI to create the collection. Finally, you can add the collection to the deploy scripts so that it will be updated in future deployments (https://github.com/pulibrary/pul_solr/blob/main/config/collections.yml).
+This repository updates, but does not create, collections. To add a new collection:
+- create the collection config here
+- deploy to get the config up to the server
+- use the UI to create the collection
+- add the collection to the deploy scripts so that it will be updated in future deployments (https://github.com/pulibrary/pul_solr/blob/main/config/collections.yml)
+- add the collection to the `config_map` in the relevant `/config/deploy/<env>.rb` file so that it will be backed up
 
 **Note: Each collection should be created with a replication factor of 2 at minimum.**
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ inventory](https://docs.google.com/spreadsheets/d/118O7JeVEPaoVsCIxoWLdDTctcTCe4
 ## Adding a new core
 
 This repository updates, but does not create, collections. To add a new collection:
-- create the collection config here
+- add the new collection's configuration to this project's `solr_configs` directory
+- add the new solr configuration location and config set name to the `config_map` in the relevant `/config/deploy/<env>.rb` file so it will be uploaded to zookeeper
 - deploy to get the config up to the server
 - use the UI to create the collection
-- add the collection to the deploy scripts so that it will be updated in future deployments (https://github.com/pulibrary/pul_solr/blob/main/config/collections.yml)
-- add the collection to the `config_map` in the relevant `/config/deploy/<env>.rb` file so that it will be backed up
+- add the collection to the deploy scripts (https://github.com/pulibrary/pul_solr/blob/main/config/collections.yml) collections listed in `collections.yml` will be updated in future deployments and also backed up by the rake task
 
 **Note: Each collection should be created with a replication factor of 2 at minimum.**
 
@@ -85,7 +85,7 @@ SOLR_URL=http://localhost:8983/solr bundle exec cap development "collections:del
 
 ## SolrCloud Backups
 
-Backups are implemented as a ruby service class wrapped in a rake task that's invoked by cron (scheduled via whenever / capistrano). A collection must be listed in the `config_map` of the `/config/deploy/<env>.rb` file to generate a backup.
+Backups are implemented as a ruby service class wrapped in a rake task that's invoked by cron (scheduled via whenever / capistrano). A collection must be listed in the collection lists in `config/collections.yml` to generate a backup.
 
 If a specific backup did not complete and you want more information, consult the Ruby log for the requeststatus and check it with the [requeststatus api call](https://lucene.apache.org/solr/guide/8_4/collections-api.html#requeststatus).
 

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ SOLR_URL=http://localhost:8983/solr bundle exec cap development "collections:del
 
 ## SolrCloud Backups
 
-Backups are implemented as a ruby service class wrapped in a rake task that's invoked by cron (scheduled via whenever / capistrano)
+Backups are implemented as a ruby service class wrapped in a rake task that's invoked by cron (scheduled via whenever / capistrano). A collection must be listed in the `config_map` of the `/config/deploy/<env>.rb` file to generate a backup.
 
-If a specific backup did not complete and you want more information, consult the log for the requeststatus and check it with the [requeststatus api call](https://lucene.apache.org/solr/guide/8_4/collections-api.html#requeststatus).
+If a specific backup did not complete and you want more information, consult the Ruby log for the requeststatus and check it with the [requeststatus api call](https://lucene.apache.org/solr/guide/8_4/collections-api.html#requeststatus).
 
 ### Restoring a backup
 


### PR DESCRIPTION
Follows up on #438.

Updates the README section about adding new Solr cores:
- makes the instructions a bulleted list
- adds an items for adding the new collection to the config for backups