### PR TITLE
[catalog] Use facet.method enum for facet fields with a few distinct values

### DIFF
--- a/solr_configs/catalog-production-v2/conf/solrconfig.xml
+++ b/solr_configs/catalog-production-v2/conf/solrconfig.xml
@@ -349,6 +349,9 @@
       <str name="f.advanced_location_s.facet.sort">index</str>
       <str name="f.language_facet.facet.limit">1000</str>
       <str name="f.advanced_location_s.facet.limit">500</str>
+      <str name="f.access_facet.facet.method">enum</str>
+      <str name="f.format.facet.method">enum</str>
+      <str name="f.location.facet.method">enum</str>
     </lst>
   </initParams>
 


### PR DESCRIPTION
The [solr documentation for facet.method](https://solr.apache.org/guide/8_8/faceting.html#field-value-faceting-parameters) says that `enum` 'is recommended for faceting multi-valued fields that have only a few distinct values'.

I tried sending these facet.method values along with empty queries to our production solr. Without specifying enum, the median response time was 10.587 seconds.  With it, it was almost a second faster: 9.657 seconds.

Note that using `enum` as the facet.method for other facet fields (e.g. sudoc, lc classification, and advanced location) also improves performance for empty queries, but performs slower when there is actually a query, which seems like the much more common case.

I ran load tests on the catalog-performance and catalog-staging solr collections.  Here are the results:

catalog-performance (400,000 requests over 31,213 documents)
|                    | With enum (this PR) | main    |
|--------------------|---------------------|---------|
| median multi-word  |    245 ms          | 140 ms  |
| p99 multi-word     |           765 ms    | 988 ms  |
| median single-word |      244 ms        | 135 ms  |
| p99 single-word    |        1349 ms      | 1245 ms |

catalog-staging (40,000 requests over 22,078,023 documents)
|                    | With enum (this PR) | main    |
|--------------------|---------------------|---------|
| median multi-word  |  1026 ms        | 1109 ms  |
| p99 multi-word     |     24112 ms   | 23269 ms  |
| median single-word |   833 ms      | 767 ms  |
| p99 single-word    |  25211 ms    | 24993 ms |