### PR TITLE
Upgrade net-ssh to enable more stringent ssh algorithms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
-    net-ssh (7.2.1)
+    net-ssh (7.3.0)
     ostruct (0.6.1)
     pry (0.14.2)
       coderay (~> 1.1)


### PR DESCRIPTION
Recent versions of OSX require more stringent ssh algorithms. Without this upgrade users of MacOS 15.2+ will get this error: 

> Exception while executing as deploy@lib-solr-prod7: could not settle on encryption_client algorithm (SSHKit::Runner::ExecuteError)
Server encryption_client preferences: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
Client encryption_client preferences:

More details here: https://github.com/net-ssh/net-ssh/issues/956