### PR TITLE
[catalog] Remove deprecated LatLon field type

### DIFF
--- a/solr_configs/catalog-production-v2/conf/schema.xml
+++ b/solr_configs/catalog-production-v2/conf/schema.xml
@@ -480,9 +480,6 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-
-    <!-- A specialized field for geospatial search. If indexed, this fieldType must not be multivalued. -->
-    <fieldType name="location" class="solr.LatLonType" subFieldSuffix="_coordinate"/>
  </types>
 
 
@@ -575,8 +572,6 @@
 
     <!-- Type used to index the lat and lon components for the "location" FieldType -->
    <dynamicField name="*_coordinate"  type="pdouble" indexed="true"  stored="false"/>
-
-   <dynamicField name="*_p"  type="location" indexed="true" stored="true"/>
 
     <!-- some trie-coded dynamic fields for faster range queries -->
    <dynamicField name="*_ti" type="pint"    indexed="true"  stored="true"/>


### PR DESCRIPTION
[This was deprecated in Solr 7](https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-7.html#spatial-fields)!