### PR TITLE
[catalog] Add source language of translation field

### DIFF
--- a/solr_configs/catalog-production-v2/conf/schema.xml
+++ b/solr_configs/catalog-production-v2/conf/schema.xml
@@ -536,6 +536,7 @@
    <field name="homoit_subject_facet" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="local_subject_facet" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="siku_subject_facet" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="original_language_of_translation_facet" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="author_int" type="author" indexed="true" stored="false" multiValued="true"/>
    <field name="title_sort" type="alphaNumSort" indexed="true" stored="false" />
     <!-- pub_date sort uses new trie-based int fields, which are recommended for any int and are displayable, sortable, and range-quer


### PR DESCRIPTION
This allows the source language to be displayed in the show page and the raw JSON.

Helps with https://github.com/pulibrary/orangelight/issues/4634