### PR TITLE
Get solr9-staging deploying again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Uploading JARs as part of the config set is disallowed by zookeeper for security reasons
+*.jar export-ignore

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -119,7 +119,7 @@ namespace :configsets do
   end
 
   def update_configset(config_dir:, config_set:)
-    execute "cd /opt/solr/bin && ./solr zk -upconfig -d #{File.join(release_path, "solr_configs", config_dir)} -n #{config_set} -z #{zk_host}"
+    execute "cd /opt/solr/bin && ./solr zk upconfig -d #{File.join(release_path, "solr_configs", config_dir)} -n #{config_set} -z #{zk_host}"
   end
 
   def delete_configset(config_set)

--- a/config/deploy/solr9_staging.rb
+++ b/config/deploy/solr9_staging.rb
@@ -1,4 +1,4 @@
-server 'lib-solr-staging1.princeton.edu', user: 'deploy', roles: %{main}
+server 'lib-solr-staging2.princeton.edu', user: 'deploy', roles: %{main}
 
 # This is used to create part of the backup directory path
 set :whenever_host, ->{ "solr9" }


### PR DESCRIPTION
* `./solr zk -upconfig` is now simply `./solr zk upconfig` (no hyphen).  This is backwards compatible with solr 8.
* lib-solr-staging1 has some problem with bundler, so we use the freshly rebuild lib-solr-staging2 instead
* Don't upload JAR files as part of the config set, since zookeeper now rejects them for security reasons.  We achieve this with capistrano's .gitattributes feature (see https://github.com/capistrano/capistrano/pull/626)