### PR TITLE
[docker] Update path to run-initdb script in lando script

### DIFF
--- a/docker/lando-start.sh
+++ b/docker/lando-start.sh
@@ -33,7 +33,7 @@ chown -R solr:solr /solrconf
 chown -R solr:solr /opt/solr
 chown -R solr:solr /var/solr
 
-. /opt/docker-solr/scripts/run-initdb
+. /opt/solr/docker/scripts/run-initdb
 
 # Go down to solr and run
 if [ "$LANDO_SOLR_CUSTOM" != "none" ]; then


### PR DESCRIPTION
Previously, starting this container with lando with the lando-start.sh command gave the error:

```
server/scripts/lando-start.sh: line 36: /opt/docker-solr/scripts/run-initdb: No such file or directory
```

The path to this script has changed slightly!

I confirmed that this script works with the updated path with:

1. In pul_solr: `docker build -t testing-solr-build docker`
1. In orangelight, `lando destroy -y`
1. In orangelight, update the image name for all solr containers to `testing-solr-build`
1. In orangelight, `bundle exec rake servers:start`

Thanks to @hackartisan for finding this issue!