### PR TITLE
Both solr8 and solr9 back up to the same base location

### DIFF
--- a/lib/tasks/pul_solr.rake
+++ b/lib/tasks/pul_solr.rake
@@ -47,9 +47,5 @@ def allowed_hosts
 end
 
 def backup_path(host)
-  if host == "solr8"
-    "/solr/data/backups/cloud_backup"
-  else
-    "/solr/backups/cloud_backup"
-  end
+  "/solr/backups/cloud_backup"
 end


### PR DESCRIPTION
refs #520
refs pulibrary/princeton_ansible#7018
refs pulibrary/princeton_ansible#7009
refs pulibrary/princeton_ansible#6959
