### PR TITLE
[catalog] Add language_iana_s to the default fl

### DIFF
--- a/solr_configs/catalog-production-v3/conf/solrconfig.xml
+++ b/solr_configs/catalog-production-v3/conf/solrconfig.xml
@@ -344,6 +344,7 @@
         cataloged_tdt,
         contained_in_s,
         call_number_display,
+        language_iana_s,
         thumbnail_display
       </str>
 

--- a/spec/orangelight/default_fl_spec.rb
+++ b/spec/orangelight/default_fl_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'json'
+
+RSpec.describe 'default fl' do
+  include_context 'solr9'
+
+  before { delete_all }
+
+  it 'includes language_iana_s field by default' do
+    solr.add({id: 1, language_iana_s: ['ar']})
+    solr.commit
+
+    expect(
+      solr_response({q: '*'})['response']['docs'].first['language_iana_s']
+    ).to eq ['ar']
+  end
+
+end


### PR DESCRIPTION
This helps with https://github.com/pulibrary/orangelight/issues/2906, as it allows us to use the language_iana_s field to determine language tags on the search results page.