### PR TITLE
Catalog dense vector

### DIFF
--- a/solr_configs/catalog-production-v3/conf/schema.xml
+++ b/solr_configs/catalog-production-v3/conf/schema.xml
@@ -470,7 +470,8 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-    <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="768" vectorEncoding="BYTE" similarityFunction="cosine" knnAlgorithm="hnsw" hnswMaxConnections="10" hnswBeamWidth="40" />
+    <!-- <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="768" vectorEncoding="BYTE" similarityFunction="cosine" knnAlgorithm="hnsw" hnswMaxConnections="10" hnswBeamWidth="40" /> -->
+    <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="96" vectorEncoding="BYTE" similarityFunction="dot_product" />
  </types>
 
 

--- a/solr_configs/catalog-production-v3/conf/schema.xml
+++ b/solr_configs/catalog-production-v3/conf/schema.xml
@@ -470,7 +470,7 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-    <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="768" similarityFunction="cosine" knnAlgorithm="hnsw" hnswMaxConnections="10" hnswBeamWidth="40" />
+    <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="3" similarityFunction="cosine" knnAlgorithm="hnsw" hnswMaxConnections="10" hnswBeamWidth="40" />
  </types>
 
 

--- a/solr_configs/catalog-production-v3/conf/schema.xml
+++ b/solr_configs/catalog-production-v3/conf/schema.xml
@@ -471,7 +471,7 @@
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
     <!-- <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="768" vectorEncoding="BYTE" similarityFunction="cosine" knnAlgorithm="hnsw" hnswMaxConnections="10" hnswBeamWidth="40" /> -->
-    <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="96" vectorEncoding="BYTE" similarityFunction="dot_product" />
+        <fieldType name="knn_vector" class="solr.DenseVectorField" vectorEncoding="FLOAT32" vectorDimension="384" similarityFunction="dot_product" hnswMaxConnections="10" hnswBeamWidth="40" />
  </types>
 
 

--- a/solr_configs/catalog-production-v3/conf/schema.xml
+++ b/solr_configs/catalog-production-v3/conf/schema.xml
@@ -470,6 +470,7 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
+    <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="768" similarityFunction="cosine" knnAlgorithm="hnsw" hnswMaxConnections="10" hnswBeamWidth="40" />
  </types>
 
 
@@ -547,6 +548,8 @@
 
     <!-- MARCXML field - stores the full MARCXML record as a string -->
    <field name="marcxml" type="string" indexed="false" stored="true" multiValued="false"/>
+   <!-- DenseVectorField field for semantic search -->
+   <field name="text_embeddings" type="knn_vector" indexed="true" stored="true"/>
 
     <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
         will be used if the name matches any of the patterns.

--- a/solr_configs/catalog-production-v3/conf/schema.xml
+++ b/solr_configs/catalog-production-v3/conf/schema.xml
@@ -470,7 +470,7 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-    <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="3" similarityFunction="cosine" knnAlgorithm="hnsw" hnswMaxConnections="10" hnswBeamWidth="40" />
+    <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="768" vectorEncoding="BYTE" similarityFunction="cosine" knnAlgorithm="hnsw" hnswMaxConnections="10" hnswBeamWidth="40" />
  </types>
 
 

--- a/solr_configs/catalog-production-v3/conf/solrconfig.xml
+++ b/solr_configs/catalog-production-v3/conf/solrconfig.xml
@@ -385,7 +385,20 @@
       <str name="defType">lucene</str>
     </lst>
   </requestHandler>
-  
+
+  <requestHandler name="/semantic" class="solr.SearchHandler" initParams="searchParams">
+    <!-- a lucene request handler for using the JSON Query DSL, for semantic search
+         Using a separate request handler as a work around to
+         https://issues.apache.org/jira/browse/SOLR-16916
+    -->
+    <!-- default values for query parameters can be specified, these
+         will be overridden by parameters in the request
+      -->
+    <lst name="defaults">
+      <str name="defType">lucene</str>
+    </lst>
+  </requestHandler>
+
   <!-- for requests to get a single document; use id=666 instead of q=id:666 -->
   <requestHandler name="document" class="solr.SearchHandler" >
     <lst name="defaults">


### PR DESCRIPTION
related to https://github.com/pulibrary/dacs_handbook/issues/351

Adds a new handler to use it in the  catalog semantic search. It works with defType lucene. 

The dense vector field uses the knn algorithm https://solr.apache.org/guide/solr/latest/query-guide/dense-vector-search.html#densevectorfield

https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html#solr-9-0

The text embeddings were generated locally using https://github.com/pulibrary/dedup-text-embeddings/pull/1  and the model 'multi-qa-mpnet-base-cos-v1'

To search using the knn index , solr expects a q param of `"{!knn f=text_embeddings topK=10}[0.010338805615901947,0.02806314453482628,0.020983939990401268]"` and with solr9 we need to set the defType to lucene.

`http://localhost:61903/solr/orangelight-core-dev/select?defType=lucene&indent=true&q.op=OR&q=%7B!knn%20f%3Dtext_embeddings%20topK%3D10%7D%5B0.010338805615901947%2C0.02806314453482628%2C0.020983939990401268%5D&useParams=`

```
{
  "responseHeader":{
    "status":0,
    "QTime":8,
    "params":{
      "q":"{!knn f=text_embeddings topK=10}[0.010338805615901947,0.02806314453482628,0.020983939990401268]",
      "defType":"lucene",
      "indent":"true",
      "q.op":"OR",
      "useParams":""
    }
  },
  "response":{
    "numFound":2,
    "start":0,
    "maxScore":0.9992631,
    "numFoundExact":true,
    "docs":[{
      "id":"9923849243506421",
      "title_display":"Vercingétorix. Histoire du pays gaulois depuis ses origines jusqu'à la conquête romaine",
      "author_display":["Colomb, Georges"],
      "score":0.9992631
    },{
      "id":"9923843813506421",
      "title_display":"The bright land",
      "author_display":["Fairbank, Janet Ayer"],
      "score":0.7314496
    }]
  },
  "facet_counts":{
    "facet_queries":{ },
    "facet_fields":{
      "format":[ ],
      "language_facet":[ ],
      "pub_date_start_sort":[ ],
      "advanced_location_s":[ ]
    },
    "facet_ranges":{ },
    "facet_intervals":{ },
    "facet_heatmaps":{ }
  }
}
```

