### PR TITLE
[catalog] add figgy_1display to the default fl

### DIFF
--- a/solr_configs/catalog-production-v3/conf/solrconfig.xml
+++ b/solr_configs/catalog-production-v3/conf/solrconfig.xml
@@ -341,6 +341,7 @@
         holdings_1display,
         electronic_access_1display,
         electronic_portfolio_s,
+        figgy_1display,
         cataloged_tdt,
         contained_in_s,
         call_number_display,


### PR DESCRIPTION
This allows us to use it in logic on the search results page to determine that there is an online option:

<img width="758" height="275" alt="A search result for Dīwān by Aḥmad ibn ʻAbd Allāh Ibn Zaydūn.  It has a link to Digital Content" src="https://github.com/user-attachments/assets/10fae92c-3ad2-4e8a-ab13-8e6e80a2fe2b" />

Closes https://github.com/pulibrary/orangelight/issues/5979

Thanks to @christinach for diagnosing the problem!