### PR TITLE
Use an ICU sort key for title sorting, rather than a string

### DIFF
--- a/solr_configs/catalog-production-v3/conf/schema.xml
+++ b/solr_configs/catalog-production-v3/conf/schema.xml
@@ -454,6 +454,8 @@
       </analyzer>
     </fieldType>
 
+    <fieldType name="icuSortKey" class="solr.ICUCollationField" locale="" strength="primary" />
+
     <!-- since fields of this type are by default not stored or indexed,
          any data added to them will be ignored outright.  -->
     <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
@@ -530,6 +532,7 @@
    <field name="original_language_of_translation_facet" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="author_int" type="author" indexed="true" stored="false" multiValued="true"/>
    <field name="title_sort" type="alphaNumSort" indexed="true" stored="false" />
+   <field name="title_sort_key" type="icuSortKey" indexed="false" stored="false" docValues="true" />
     <!-- pub_date sort uses new trie-based int fields, which are recommended for any int and are displayable, sortable, and range-quer
    we use 'pint' for faster range-queries. -->
    <field name="pub_date_start_sort" type="pint" indexed="true" stored="true" multiValued="false"/>
@@ -728,4 +731,9 @@
    <copyField source="title_addl_la" dest="text"/>
 
    <copyField source="cjk_notes" dest="cjk_text"/>
+
+   <!-- temporary copy Field for backwards compatibility. Once orangelight uses title_sort_key
+    for sorting and we have done a full reindex, we can start indexing directly
+    into title_sort_key directly, and remove title_sort altogether -->
+  <copyField source="title_sort" dest="title_sort_key" />
 </schema>

--- a/spec/orangelight/title_sort_spec.rb
+++ b/spec/orangelight/title_sort_spec.rb
@@ -7,26 +7,26 @@ RSpec.describe 'title sort' do
   before { delete_all }
 
   it 'sorts titles that start with diacritics' do
-    solr.add({id: 1, title_sort: 'Falsche Freunde'})
-    solr.add({id: 2, title_sort: 'Im Morgenrot '})
-    solr.add({id: 3, title_sort: 'Üble Sache Maloney!'})
+    solr.add({id: 1, title_sort_key: 'Falsche Freunde'})
+    solr.add({id: 2, title_sort_key: 'Im Morgenrot '})
+    solr.add({id: 3, title_sort_key: 'Üble Sache Maloney!'})
     solr.commit
 
     expect(
-      solr_response({q: '*', sort: 'title_sort ASC'})['response']['docs']
+      solr_response({q: '*', sort: 'title_sort_key ASC'})['response']['docs']
         .map {|doc| doc['id']}
     ).to eq ['1', '2', '3']
   end
 
   it 'sorts titles without regard to capitalization' do
-    solr.add({id: 4, title_sort: 'Xyz'})
-    solr.add({id: 3, title_sort: 'xy'})
-    solr.add({id: 2, title_sort: 'abd'})
-    solr.add({id: 1, title_sort: 'ABC'})
+    solr.add({id: 4, title_sort_key: 'Xyz'})
+    solr.add({id: 3, title_sort_key: 'xy'})
+    solr.add({id: 2, title_sort_key: 'abd'})
+    solr.add({id: 1, title_sort_key: 'ABC'})
     solr.commit
 
     expect(
-      solr_response({q: '*', sort: 'title_sort ASC'})['response']['docs']
+      solr_response({q: '*', sort: 'title_sort_key ASC'})['response']['docs']
         .map {|doc| doc['id']}
     ).to eq ['1', '2', '3', '4']
   end


### PR DESCRIPTION
Helps with https://github.com/pulibrary/bibdata/issues/3404

We confirmed that, given the same data indexed into a collection, the `title_sort` adds substantial data to the field cache, while `title_sort_key` does not add any data to the field cache.

The tradeoffs that I expect:
- This will take a lot less memory than the previous implementation (the sort key is very compact, and uses docValues)
- This may provide more correct ordering for non-English titles
- This may take longer to index

For backwards compatibility, this commit includes both the new sortkey and the old title_sort field.  The next steps would be:

* Full reindex
* Change orangelight to look at `title_sort_key` rather than `title_sort`
* Change bibdata to index directly into `title_sort_key` rather than `title_sort`
* Remove all references to `title_sort` from pul solr