### PR TITLE
[DSS] Use a correct cache type

### DIFF
--- a/solr_configs/dss-production/conf/solrconfig.xml
+++ b/solr_configs/dss-production/conf/solrconfig.xml
@@ -90,16 +90,16 @@
 
 
   <query>
-    <filterCache class="solr.FastLRUCache"
+    <filterCache class="solr.search.CaffeineCache"
                  size="2048"
                  initialSize="2048"
                  autowarmCount="64"/>
-    <queryResultCache class="solr.LRUCache"
+    <queryResultCache class="solr.search.CaffeineCache"
                       size="4096"
                       initialSize="4096"
                       autowarmCount="32"/>
 
-    <documentCache class="solr.LRUCache"
+    <documentCache class="solr.search.CaffeineCache"
                    size="4096"
                    initialSize="4096"/>
 


### PR DESCRIPTION
Solr 9 removed the LRUCache and FastLRUCache classes (see https://github.com/apache/solr/blob/647de260b06f2903de833587af4389603e4bf42e/solr/solr-ref-guide/modules/upgrade-notes/pages/major-changes-in-solr-9.adoc#deprecations-and-removals)

Hopefully this helps with the following log noise:

```
ERROR (qtp238564722-918-14ed3aadd673e0fdda3c8a3166564cd5) [c:dss-production s:shard1 r:core_node16 x:dss-production_shard1_replica_n15 t:14ed3aadd673e0fdda3c8a3166564cd5] o.a.s.s.CacheConfig Error instantiating cache
org.apache.solr.common.SolrException:  Error loading class 'solr.FastLRUCache'
at org.apache.solr.core.SolrResourceLoader.findClass(SolrResourceLoader.java:554)
[...]
```