### PR TITLE
Catalog: Stop using the author_sort field

### DIFF
--- a/solr_configs/catalog-production-v3/conf/schema.xml
+++ b/solr_configs/catalog-production-v3/conf/schema.xml
@@ -729,10 +729,4 @@
    <copyField source="title_addl_la" dest="text"/>
 
    <copyField source="cjk_notes" dest="cjk_text"/>
-
-   <!-- Backwards compatibility: we are moving from author_sort to author_sort_key.
-    We need to do a full reindex, then switch Orangelight to use author_sort_key,
-    then switch Bibdata to index directly into author_sort_key and remove this copyField
-    -->
-    <copyField source="author_sort" dest="author_sort_key" />
 </schema>


### PR DESCRIPTION
We will be using the more memory efficient author_sort_key moving forward.

We need to merge and deploy https://github.com/pulibrary/orangelight/pull/6086 first